### PR TITLE
Fix: reject unknown fields in config

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -8,11 +8,13 @@ use serde::{
 use crate::theme::ThemeSource;
 
 #[derive(Serialize, Deserialize, Default)]
+#[serde(deny_unknown_fields)]
 pub struct Config {
     pub highlighting: HighlightingConfig,
 }
 
 #[derive(Serialize, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub struct HighlightingConfig {
     /// Either the name of a built-in theme (`"simple"`, `"patina"`,
     /// `"lavender"`) or a string in the form `"file:mytheme.toml"` pointing to


### PR DESCRIPTION
Add `#[serde(deny_unknown_fields)]` to `Config` and `HighlightingConfig` so that typos in section names (e.g. `[nonsense]` instead of `[highlighting]`) or unknown keys inside `[highlighting]` are reported as errors instead of being silently ignored.

Before this change, a misconfigured file would appear valid (`check` would report "Everything is OK") while all settings were quietly falling back to defaults.

# Test 

Using `Nord` instead of `nord` in:

```config.toml
[highlighting]
# Either the name of a built-in theme (e.g. `"simple"`, `"patina"`) or a string
# in the form `"file:/path/mytheme.toml"` pointing to a custom theme toml file.
theme = "Nord"
```

now correctly produces a clear error message:

```
patina restart
zsh-patina: Unable to read config file "/Users/andrea/.config/zsh-patina/config.toml"

Caused by:
    Unsupported theme source: Nord for key "default.highlighting.theme" in /Users/andrea/.config/zsh-patina/config.toml TOML file
```
