### PR TITLE
Load config_file from $ZSH_PATINA_CONFIG_FILE if set

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ A flake is provided to make the executable the plugin requires available in `/ni
 
 zsh-patina can be configured through an optional configuration file at the following locations (in order of precedence):
 
+* `$ZSH_PATINA_CONFIG_FILE` if set
 * `$XDG_CONFIG_HOME/zsh-patina/config.toml` (if `$XDG_CONFIG_HOME` is set)
 * `~/.config/zsh-patina/config.toml`
 

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -93,7 +93,8 @@ pub fn check(
         print_bullet(
             &format!(
                 "No configuration file found at `$XDG_CONFIG_HOME/zsh-patina/config.toml' \
-                or `{}/.config/zsh-patina/config.toml'. Using default settings.",
+                or `{}/.config/zsh-patina/config.toml' and $ZSH_PATINA_CONFIG_FILE is unset. \
+				Using default settings.",
                 dirs::home_dir()
                     .and_then(|p| p.to_str().map(|s| s.to_string()))
                     .unwrap_or_else(|| "~".to_string())

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,12 +182,22 @@ impl<'de> Deserialize<'de> for DynamicConfig {
 /// Returns the path to the configuration file if it exists. The configuration
 /// file is searched in the following locations (in order):
 ///
-/// 1. `$XDG_CONFIG_HOME/zsh-patina/config.toml` if the `XDG_CONFIG_HOME`
+/// 1. $ZSH_PATINA_CONFIG_FILE if it is set.
+/// 2. `$XDG_CONFIG_HOME/zsh-patina/config.toml` if the `XDG_CONFIG_HOME`
 ///    environment variable is set and points to an absolute path
-/// 2. `~/.config/zsh-patina/config.toml`
+/// 3. `~/.config/zsh-patina/config.toml`
 ///
 /// If no configuration file is found, the function returns `Ok(None)`.
 pub fn config_file_path() -> Result<Option<PathBuf>> {
+    if let Some(config_file) = env::var_os("ZSH_PATINA_CONFIG_FILE")
+        && !config_file.is_empty()
+    {
+        let config_file = PathBuf::from(config_file);
+        if config_file.exists() {
+            return Ok(Some(config_file));
+        }
+    }
+
     if let Some(xdg) = env::var_os("XDG_CONFIG_HOME")
         && !xdg.is_empty()
     {

--- a/src/config.rs
+++ b/src/config.rs
@@ -182,7 +182,7 @@ impl<'de> Deserialize<'de> for DynamicConfig {
 /// Returns the path to the configuration file if it exists. The configuration
 /// file is searched in the following locations (in order):
 ///
-/// 1. $ZSH_PATINA_CONFIG_FILE if it is set.
+/// 1. `$ZSH_PATINA_CONFIG_FILE` if it is set.
 /// 2. `$XDG_CONFIG_HOME/zsh-patina/config.toml` if the `XDG_CONFIG_HOME`
 ///    environment variable is set and points to an absolute path
 /// 3. `~/.config/zsh-patina/config.toml`


### PR DESCRIPTION
The title should be self-explanatory.
The reason I want this is it makes more sense for me to keep related configs together and would rather have my `zsh-patina` config file inside of my `$ZDOTDIR` than having to add yet another subdirectory of `~/.config` to version control of my dotfiles.