### PR TITLE
Reset command substitution base highlighting to terminal defaults 

### DIFF
--- a/README.md
+++ b/README.md
@@ -404,6 +404,17 @@ background = "red"
 bold = true
 ```
 
+More specific scope entries completely replace less specific ones: no attributes are inherited or merged.
+
+For example, if you use:
+
+```toml
+"variable" = { foreground = "blue", underline = true }
+"variable.parameter" = { foreground = "magenta" }
+```
+
+Then `variable.parameter` will be magenta but not underlined. In consequence, setting the `{}` style will reset the highlighting of that scope to your terminal's defaults.
+
 Note that as of Zsh 5.9, it's unfortunately not possible to show text on the command line in italics as the ZLE (Zsh Line Editor) only supports [bold and underlined](https://zsh.sourceforge.io/Doc/Release/Zsh-Line-Editor.html#Character-Highlighting).
 
 ### Scopes

--- a/themes/catppuccin-frappe.toml
+++ b/themes/catppuccin-frappe.toml
@@ -55,6 +55,9 @@ source = "#c6d0f5"
 # history expansions
 "meta.group.expansion.history" = "#e78284"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#c6d0f5" }
+
 # dynamic items
 "dynamic.callable" = "#8caaee"
 "dynamic.callable.missing" = "#e78284"

--- a/themes/catppuccin-latte.toml
+++ b/themes/catppuccin-latte.toml
@@ -55,6 +55,9 @@
 # history expansions
 "meta.group.expansion.history" = "#d20f39"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#4c4f69" }
+
 # dynamic items
 "dynamic.callable" = "#1e66f5"
 "dynamic.callable.missing" = "#d20f39"

--- a/themes/catppuccin-macchiato.toml
+++ b/themes/catppuccin-macchiato.toml
@@ -55,6 +55,9 @@
 # history expansions
 "meta.group.expansion.history" = "#ed8796"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#cad3f5" }
+
 # dynamic items
 "dynamic.callable" = "#8aadf4"
 "dynamic.callable.missing" = "#ed8796"

--- a/themes/catppuccin-mocha.toml
+++ b/themes/catppuccin-mocha.toml
@@ -55,6 +55,9 @@ source = "#cdd6f4"
 # history expansions
 "meta.group.expansion.history" = "#f38ba8"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#cdd6f4" }
+
 # dynamic items
 "dynamic.callable" = "#89b4fa"
 "dynamic.callable.missing" = "#f38ba8"

--- a/themes/classic.toml
+++ b/themes/classic.toml
@@ -48,6 +48,9 @@
 # history expansions
 "meta.group.expansion.history" = "#87d75f"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = "green"
 "dynamic.callable.missing" = { foreground = "red", bold = true }

--- a/themes/kanagawa.toml
+++ b/themes/kanagawa.toml
@@ -67,6 +67,9 @@ source = "#dcd7ba"
 # history expansions
 "meta.group.expansion.history" = "#7fb4ca"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#dcd7ba" }
+
 # fallback for any token not explicitly mentioned above
 "meta" = "#7fb4ca"
 

--- a/themes/lavender.toml
+++ b/themes/lavender.toml
@@ -44,6 +44,9 @@
 # history expansions
 "meta.group.expansion.history" = "yellow"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = "magenta"
 "dynamic.callable.missing" = "red"

--- a/themes/nord.toml
+++ b/themes/nord.toml
@@ -47,6 +47,9 @@
 # history expansions
 "meta.group.expansion.history" = "#EBCB8B"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = "#88C0D0"
 "dynamic.callable.missing" = "#BF616A"

--- a/themes/patina.toml
+++ b/themes/patina.toml
@@ -44,6 +44,9 @@
 # history expansions
 "meta.group.expansion.history" = "yellow"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = "cyan"
 "dynamic.callable.missing" = "red"

--- a/themes/simple.toml
+++ b/themes/simple.toml
@@ -26,6 +26,9 @@
 # history expansions
 "meta.group.expansion.history" = "yellow"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = {}
 "dynamic.callable.missing" = "red"

--- a/themes/solarized.toml
+++ b/themes/solarized.toml
@@ -34,6 +34,9 @@
 # history expansions
 "meta.group.expansion.history" = "#268bd2"
 
+# reset command substitutions to the theme's default foreground color
+"meta.group.expansion.command.parens" = { foreground = "#839496" }
+
 # dynamic items
 "dynamic.callable" = "#b58900"
 "dynamic.callable.missing" = "#dc322f"

--- a/themes/tokyonight.toml
+++ b/themes/tokyonight.toml
@@ -20,6 +20,9 @@
 # history expansions
 "meta.group.expansion.history" = "#E6C384"
 
+# reset command substitutions to terminal defaults
+"meta.group.expansion.command.parens" = {}
+
 # dynamic items
 "dynamic.callable" = "#7DCFFF"
 "dynamic.callable.missing" = "#F7768E"


### PR DESCRIPTION
Take for instance the following:

    echo test
    result=$(echo test)

The above currently highlights `echo test` differently according to whether it stands alone, or within a command substitution, `$(echo test)`.

In the latter case, with the current themes, `$(echo test)` would use the `"string.unquoted.shell"`, which inherits the colour for the "string" scope: any bit of `$(echo test)` that doesn't get a more specific override would then use the colour of `"string"`.

This Pull Requests introduces a **reset** of the style of command substitutions to the terminal defaults.
It also documents default highlighting style mechanism in the `README`.

Discussed in #42.