### PR TITLE
Recognise self-referencing aliases as being valid

### DIFF
--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -80,17 +80,19 @@ _zsh_patina_resolve_callable() {
     local word=$1
     shift
     local -a visited=("$@")
-    local alias_content
+    local matched_alias
 
     if (( $+aliases[(e)$word] )); then
-        alias_content=$aliases[$word]
+        matched_alias=$aliases[$word]
     elif (( $+galiases[(e)$word] )); then
-        alias_content=$galiases[$word]
+        matched_alias=$galiases[$word]
+    else
+        unset matched_alias
     fi
 
     # recursively resolve unvisited aliases
-    if (( $+alias_content && ! ${visited[(Ie)$word]} )); then
-        _zsh_patina_resolve_alias "$alias_content" "$word" "${visited[@]}"
+    if (( $+matched_alias && ! ${visited[(Ie)$word]} )); then
+        _zsh_patina_resolve_alias "$matched_alias" "$word" "${visited[@]}"
         return
     fi
 

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -83,19 +83,29 @@ _zsh_patina_resolve_callable() {
 
     if (( $+aliases[(e)$word] )); then
         if (( ${visited[(Ie)$word]} )); then
-            # cycle detected: treat this as invalid
-            REPLY=m
+            if [[ "$word" != "$visited[1]" ]]; then
+                # cycle detected: treat this as invalid
+                REPLY=m
+                return
+            fi
+        else
+            _zsh_patina_resolve_alias "$aliases[$word]" "$word" "${visited[@]}"
             return
         fi
-        _zsh_patina_resolve_alias "$aliases[$word]" "$word" "${visited[@]}"
     elif (( $+galiases[(e)$word] )); then
         if (( ${visited[(Ie)$word]} )); then
-            # cycle detected: treat this as invalid
-            REPLY=m
+            if [[ "$word" != "$visited[1]" ]]; then
+                # cycle detected: treat this as invalid
+                REPLY=m
+                return
+            fi
+        else
+            _zsh_patina_resolve_alias "$galiases[$word]" "$word" "${visited[@]}"
             return
         fi
-        _zsh_patina_resolve_alias "$galiases[$word]" "$word" "${visited[@]}"
-    elif (( $+functions[(e)$word] )); then
+    fi
+
+    if (( $+functions[(e)$word] )); then
         REPLY=f
     elif (( $+builtins[(e)$word] )); then
         REPLY=b

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -80,29 +80,18 @@ _zsh_patina_resolve_callable() {
     local word=$1
     shift
     local -a visited=("$@")
+    local alias_content
 
     if (( $+aliases[(e)$word] )); then
-        if (( ${visited[(Ie)$word]} )); then
-            if [[ "$word" != "$visited[1]" ]]; then
-                # cycle detected: treat this as invalid
-                REPLY=m
-                return
-            fi
-        else
-            _zsh_patina_resolve_alias "$aliases[$word]" "$word" "${visited[@]}"
-            return
-        fi
+        alias_content=$aliases[$word]
     elif (( $+galiases[(e)$word] )); then
-        if (( ${visited[(Ie)$word]} )); then
-            if [[ "$word" != "$visited[1]" ]]; then
-                # cycle detected: treat this as invalid
-                REPLY=m
-                return
-            fi
-        else
-            _zsh_patina_resolve_alias "$galiases[$word]" "$word" "${visited[@]}"
-            return
-        fi
+        alias_content=$galiases[$word]
+    fi
+
+    # recursively resolve unvisited aliases
+    if (( $+alias_content && ! ${visited[(Ie)$word]} )); then
+        _zsh_patina_resolve_alias "$alias_content" "$word" "${visited[@]}"
+        return
     fi
 
     if (( $+functions[(e)$word] )); then


### PR DESCRIPTION
For example, both of the following are valid aliases:

    alias grep='grep --color'
    alias git='noglob git'

This commit introduces tolerance in the branches where we detect a would-be recursive call in order to possibly mark it adequately.

Fixes #47.