### PR TITLE
More precisely target jobspec highlighting

### DIFF
--- a/assets/Packages/ShellScript/Bash.sublime-syntax
+++ b/assets/Packages/ShellScript/Bash.sublime-syntax
@@ -1311,14 +1311,14 @@ contexts:
     # The symbols ‘%%’ and ‘%+’ refer to the shell’s notion of the current job,
     # which is the last job stopped while it was in the foreground or started in
     # the background. The previous job may be referenced using ‘%-’.
-    - match: (%)([%+-])
+    - match: (?:(?<=^)|(?<={{metachar}}))(%)([%+-])
       captures:
         0: meta.group.expansion.job.shell
         1: punctuation.definition.variable.job.shell
         2: variable.language.job.shell
     # The character ‘%’ introduces a job specification (jobspec). Job number n
     # may be referred to as ‘%n’.
-    - match: (%)(\d+)
+    - match: (?:(?<=^)|(?<={{metachar}}))(%)(\d+)
       captures:
         0: meta.group.expansion.job.shell
         1: punctuation.definition.variable.job.shell
@@ -1328,7 +1328,7 @@ contexts:
     # refers to a stopped ce job. Using ‘%?ce’, on the other hand, refers to any
     # job containing the string ‘ce’ in its command line. If the prefix or
     # substring matches more than one job, Bash reports an error.
-    - match: (%)(\??)(\w+)
+    - match: (?:(?<=^)|(?<={{metachar}}))(%)(\??)(\w+)
       captures:
         0: meta.group.expansion.job.shell
         1: punctuation.definition.variable.job.shell
@@ -1336,7 +1336,7 @@ contexts:
         3: variable.other.readwrite.shell
     # A single ‘%’ (with no accompanying job specification) also refers to the
     # current job.
-    - match: '%'
+    - match: (?:(?<=^)|(?<={{metachar}}))%
       scope:
         meta.group.expansion.job.shell
         punctuation.definition.variable.job.shell
@@ -1493,4 +1493,3 @@ contexts:
     - include: expansion-parameter
     - include: expansion-arithmetic
     - include: expansion-command
-

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -2525,6 +2525,34 @@ mod tests {
     }
 
     #[test]
+    fn percent_jobs_are_still_job_expansions() -> Result<()> {
+        let cfg = test_cfg()?;
+
+        let highlighted = cfg.highlight("fg %")?;
+        assert_eq!(
+            highlighted,
+            vec![
+                cfg.dynamic_span(0, 2, "fg"),
+                cfg.static_span(2, 3, ARGUMENTS)?,
+                cfg.static_span(3, 4, PUNCTUATION_JOB_VARIABLE)?
+            ]
+        );
+
+        let highlighted = cfg.highlight("fg %1")?;
+        assert_eq!(
+            highlighted,
+            vec![
+                cfg.dynamic_span(0, 2, "fg"),
+                cfg.static_span(2, 3, ARGUMENTS)?,
+                cfg.static_span(3, 4, PUNCTUATION_JOB_VARIABLE)?,
+                cfg.static_span(4, 5, INTEGER_JOB)?
+            ]
+        );
+
+        Ok(())
+    }
+
+    #[test]
     fn percent_formats_are_not_job_expansions() -> Result<()> {
         let cfg = test_cfg()?;
 

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -2524,6 +2524,35 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn percent_formats_are_not_job_expansions() -> Result<()> {
+        let cfg = test_cfg()?;
+
+        let highlighted = cfg.highlight("date +%s")?;
+        assert_eq!(
+            highlighted,
+            vec![
+                cfg.dynamic_span(0, 4, "date"),
+                cfg.static_span(4, 8, ARGUMENTS)?
+            ]
+        );
+
+        let highlighted = cfg.highlight("git log --pretty=%aD")?;
+        assert_eq!(
+            highlighted,
+            vec![
+                cfg.dynamic_span(0, 3, "git"),
+                cfg.static_span(3, 7, ARGUMENTS)?,
+                cfg.static_span(7, 10, PUNCTUATION_PARAMETER)?,
+                cfg.static_span(10, 16, PARAMETER)?,
+                cfg.static_span(16, 17, OPERATOR_ASSIGNMENT_OPTION)?,
+                cfg.static_span(17, 20, ARGUMENTS)?
+            ]
+        );
+
+        Ok(())
+    }
+
     /// see https://github.com/michel-kraemer/zsh-patina/issues/45
     #[test]
     fn case_with_heredoc() -> Result<()> {

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -84,6 +84,8 @@ const OPERATOR_ARITHMETIC: &str = "keyword.operator.arithmetic.shell";
 #[cfg(test)]
 const OPERATOR_ASSIGNMENT_REDIRECTION: &str = "keyword.operator.assignment.redirection.shell";
 #[cfg(test)]
+const OPERATOR_ASSIGNMENT_OPTION: &str = "keyword.operator.assignment.option.shell";
+#[cfg(test)]
 const OPERATOR_LOGICAL_AND: &str = "keyword.operator.logical.and.shell";
 #[cfg(test)]
 const OPERATOR_LOGICAL_CONTINUE: &str = "keyword.operator.logical.continue.shell";

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -108,6 +108,8 @@ const PRECOMMAND_NOGLOB: &str = "precommand.builtin.noglob.shell";
 #[cfg(test)]
 const PUNCTUATION_COMMENT_BEGIN: &str = "punctuation.definition.comment.begin.shell";
 #[cfg(test)]
+const PUNCTUATION_JOB_VARIABLE: &str = "punctuation.definition.variable.job.shell";
+#[cfg(test)]
 const PUNCTUATION_EXPANSION_PARAMETER_BEGIN: &str =
     "punctuation.section.expansion.parameter.begin.shell";
 #[cfg(test)]
@@ -123,6 +125,8 @@ const PUNCTUATION_PARENS_END: &str = "punctuation.section.parens.end.shell";
 const PUNCTUATION_TERMINATOR_CASE: &str = "punctuation.terminator.case.shell";
 #[cfg(test)]
 const PUNCTUATION_VARIABLE: &str = "punctuation.definition.variable.shell";
+#[cfg(test)]
+const INTEGER_JOB: &str = "constant.numeric.integer.decimal.job.shell";
 
 /// A span of text with a foreground color. The range is specified in terms of
 /// character indices, not byte indices.


### PR DESCRIPTION
A lot of `%` signs aren't actrually introducing `jobspec`s: this PR tightens the scope that's recognised as `meta.group.expansion.job.shell`.

Notable everyday counter-examples:

    date +%s               << seconds since epoch
    git log --pretty=%s    << output only the subject

I added also some simple tests with these counter-examples, and some actual examples: `fg %` and fg `%1`.