### PR TITLE
Recognise new utilies installed *after* `zsh-patina activate`

### DIFF
--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -81,9 +81,6 @@ _zsh_patina_resolve_callable() {
     shift
     local -a visited=("$@")
 
-    # Refresh Zsh's command hash so newly installed utilities in PATH are found
-    rehash
-
     local matched_alias
     if (( $+aliases[(e)$word] )); then
         matched_alias=$aliases[$word]
@@ -104,6 +101,11 @@ _zsh_patina_resolve_callable() {
     elif (( $+builtins[(e)$word] )); then
         REPLY=b
     elif (( $+commands[(e)$word] )); then
+        REPLY=c
+    # $commands may stay stale until rehash after a new executable appears in
+    # an existing PATH entry.  Fall back to a targeted PATH lookup for this one
+    # word instead of refreshing the whole command hash with each keystroke.
+    elif whence -p -- "$word" >/dev/null 2>&1; then
         REPLY=c
     else
         REPLY=m

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -81,6 +81,9 @@ _zsh_patina_resolve_callable() {
     shift
     local -a visited=("$@")
 
+    # Refresh Zsh's command hash so newly installed utilities in PATH are found
+    rehash
+
     local matched_alias
     if (( $+aliases[(e)$word] )); then
         matched_alias=$aliases[$word]

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -95,19 +95,25 @@ async fn setup() -> GenericImage {
 
 /// Runs zsh-patina in a container and highlights the given buffer. Compares
 /// `$region_highlight` to the expected result.
-async fn run_highlight(
+async fn run_highlight_with(
     image: &GenericImage,
-    setup_commands: &[&str],
+    before_activate_commands: &[&str],
+    after_activate_commands: &[&str],
     buffer: &str,
     expected: &[String],
 ) {
-    let setup = if setup_commands.is_empty() {
+    let before_activate = if before_activate_commands.is_empty() {
         String::new()
     } else {
-        format!("{}; ", setup_commands.join("; "))
+        format!("{}; ", before_activate_commands.join("; "))
+    };
+    let after_activate = if after_activate_commands.is_empty() {
+        String::new()
+    } else {
+        format!("{}; ", after_activate_commands.join("; "))
     };
     let zsh_script = format!(
-        r#"eval "$(zsh-patina activate)"; {setup}
+        r#"{before_activate}eval "$(zsh-patina activate)"; {after_activate}
         BUFFER="{buffer}"; CURSOR=${{#BUFFER}}; for i in {{1..50}}; do _zsh_patina; [[ ${{#region_highlight[@]}} -gt 0 ]] && break; sleep 0.1; done;
         printf '%s\n' "${{region_highlight[@]}}""#
     );
@@ -149,6 +155,15 @@ async fn run_highlight(
         .collect::<Vec<_>>();
 
     assert_eq!(lines, expected);
+}
+
+async fn run_highlight(
+    image: &GenericImage,
+    setup_commands: &[&str],
+    buffer: &str,
+    expected: &[String],
+) {
+    run_highlight_with(image, setup_commands, &[], buffer, expected).await;
 }
 
 /// Test if a simple `ls -l` command is highlighted correctly
@@ -287,6 +302,26 @@ async fn resolve_alias() {
             h(5, 7, OPERATOR_LOGICAL_AND),
             h(8, 9, DYNAMIC_CALLABLE_ALIAS),
         ],
+    )
+    .await;
+}
+
+/// Test if a command created in an existing PATH entry after activation is
+/// highlighted correctly.
+#[tokio::test]
+#[ignore]
+async fn highlight_command_created_after_activation_in_existing_path_entry() {
+    let image = setup().await;
+
+    run_highlight_with(
+        &image,
+        &["mkdir -p /tmp/bin", "export PATH=/tmp/bin:$PATH"],
+        &[
+            "printf '#!/bin/sh\n' > /tmp/bin/freshcmd",
+            "chmod +x /tmp/bin/freshcmd",
+        ],
+        "freshcmd",
+        &[h(0, 8, DYNAMIC_CALLABLE_COMMAND)],
     )
     .await;
 }

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -93,27 +93,41 @@ async fn setup() -> GenericImage {
     }
 }
 
-/// Runs zsh-patina in a container and highlights the given buffer. Compares
-/// `$region_highlight` to the expected result.
-async fn run_highlight_with(
+/// Runs zsh-patina in a container and highlights the given
+/// buffer. Compares `$region_highlight` to the expected result. There
+/// may be two separate pre- and post- setup steps that run before and
+/// after sourcing `zsh-patina activate`, respectively. This method
+/// will somewhat emulate human user behaviour, in entering most of the
+/// buffer first, then "typing out" its last character afterwards.
+async fn run_highlight(
     image: &GenericImage,
-    before_activate_commands: &[&str],
-    after_activate_commands: &[&str],
+    setup_pre: &[&str],
+    setup_post: &[&str],
     buffer: &str,
     expected: &[String],
 ) {
-    let before_activate = if before_activate_commands.is_empty() {
+    let before_activate = if setup_pre.is_empty() {
         String::new()
     } else {
-        format!("{}; ", before_activate_commands.join("; "))
+        format!("{}; ", setup_pre.join("; "))
     };
-    let after_activate = if after_activate_commands.is_empty() {
+    let after_activate = if setup_post.is_empty() {
         String::new()
     } else {
-        format!("{}; ", after_activate_commands.join("; "))
+        format!("{}; ", setup_post.join("; "))
     };
+
+    // emulate human keystrokes triggering successive highlightings
+    let previous_buffer = buffer
+        .char_indices()
+        .next_back()
+        .map(|(idx, _)| &buffer[..idx])
+        .unwrap_or("");
     let zsh_script = format!(
-        r#"{before_activate}eval "$(zsh-patina activate)"; {after_activate}
+        r#"{before_activate}
+        eval "$(zsh-patina activate)"
+        BUFFER="{previous_buffer}"; CURSOR=${{#BUFFER}}; for i in {{1..50}}; do _zsh_patina; [[ ${{#region_highlight[@]}} -gt 0 ]] && break; sleep 0.1; done;
+        {after_activate}
         BUFFER="{buffer}"; CURSOR=${{#BUFFER}}; for i in {{1..50}}; do _zsh_patina; [[ ${{#region_highlight[@]}} -gt 0 ]] && break; sleep 0.1; done;
         printf '%s\n' "${{region_highlight[@]}}""#
     );
@@ -157,15 +171,6 @@ async fn run_highlight_with(
     assert_eq!(lines, expected);
 }
 
-async fn run_highlight(
-    image: &GenericImage,
-    setup_commands: &[&str],
-    buffer: &str,
-    expected: &[String],
-) {
-    run_highlight_with(image, setup_commands, &[], buffer, expected).await;
-}
-
 /// Test if a simple `ls -l` command is highlighted correctly
 #[tokio::test]
 #[ignore]
@@ -173,6 +178,7 @@ async fn ls_with_option() {
     let image = setup().await;
     run_highlight(
         &image,
+        &[],
         &[],
         "ls -l",
         &[
@@ -194,6 +200,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias ll='ls -l'"],
+        &[],
         "ll -a",
         &[
             h(0, 2, DYNAMIC_CALLABLE_ALIAS),
@@ -207,6 +214,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias ll='(ls -l)'"],
+        &[],
         "ll -a",
         &[
             h(0, 2, DYNAMIC_CALLABLE_ALIAS),
@@ -220,6 +228,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias lla='ll -a'", "alias ll='ls -l'"],
+        &[],
         "lla && ll",
         &[
             h(0, 3, DYNAMIC_CALLABLE_ALIAS),
@@ -233,6 +242,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias fb=foobar"],
+        &[],
         "fb",
         &[h(0, 2, DYNAMIC_CALLABLE_MISSING)],
     )
@@ -242,6 +252,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias foobar='ls -l && echo OK'"],
+        &[],
         "foobar",
         &[h(0, 6, DYNAMIC_CALLABLE_ALIAS)],
     )
@@ -251,6 +262,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias foobar='ls -l && missing OK'"],
+        &[],
         "foobar",
         &[h(0, 6, DYNAMIC_CALLABLE_MISSING)],
     )
@@ -263,6 +275,7 @@ async fn resolve_alias() {
             "alias fb='foobar --option'",
             "alias foobar='fb --another-option'",
         ],
+        &[],
         "fb",
         &[h(0, 2, DYNAMIC_CALLABLE_MISSING)],
     )
@@ -272,6 +285,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias grep='grep --color'"],
+        &[],
         "grep",
         &[h(0, 4, DYNAMIC_CALLABLE_ALIAS)],
     )
@@ -282,6 +296,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias grep='g --color'", "alias g='grep'"],
+        &[],
         "grep && g",
         &[
             h(0, 4, DYNAMIC_CALLABLE_ALIAS),
@@ -296,6 +311,7 @@ async fn resolve_alias() {
     run_highlight(
         &image,
         &["alias grep='grep --color'", "alias g='grep'"],
+        &[],
         "grep && g",
         &[
             h(0, 4, DYNAMIC_CALLABLE_ALIAS),
@@ -313,7 +329,7 @@ async fn resolve_alias() {
 async fn highlight_command_created_after_activation_in_existing_path_entry() {
     let image = setup().await;
 
-    run_highlight_with(
+    run_highlight(
         &image,
         &["mkdir -p /tmp/bin", "export PATH=/tmp/bin:$PATH"],
         &[


### PR DESCRIPTION
Hey,

Currently, if you install some new tool on your `PATH` *after* having sourced `zsh-patina activate`, that utility *won't* be highlighted as available, using dynamic highlighting.

This PR remedies that situation :-)

I could eventually nail it down in a test (included here) that would fail before, and pass after.
I took care of the procedure not being overly costly in the end:

- only using `whence`, which only looks up a single command rather than attempt to rebuild the entire `$commands` hash table.
- use it with `-p`, to only consider *commands*, not aliases, builtins or functions (these are automatically "hashed" whenever created).
- use it only in the *look-up failed* branch, as a last resort.

My only little regret is that I broke apart the original `run_highlight` method, and could only come up with a stupid name for its little cousin (`run_highlight_with`). I think having both is probably fine, but the naming could be improved.

What do you think?