### PR TITLE
Add automatic light/dark theme switching

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "arc-swap"
+version = "1.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a3a1fd6f75306b68087b831f025c712524bcb19aad54e557b1129cfa0a2b207"
+dependencies = [
+ "rustversion",
+]
+
+[[package]]
+name = "ashpd"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de3d60bee1a1d38c2077030f4788e1b4e31058d2e79a8cfc8f2b440bd44db290"
+dependencies = [
+ "async-fs",
+ "async-net",
+ "enumflags2",
+ "futures-channel",
+ "futures-util",
+ "rand 0.8.6",
+ "serde",
+ "serde_repr",
+ "url",
+ "zbus",
+]
+
+[[package]]
 name = "askama"
 version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -152,6 +179,194 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "1.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81953c529336010edd6d8e358f886d9581267795c61b19475b71314bffa46d35"
+dependencies = [
+ "concurrent-queue",
+ "event-listener 2.5.3",
+ "futures-core",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-fs"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8034a681df4aed8b8edbd7fbe472401ecf009251c8b40556b304567052e294c5"
+dependencies = [
+ "async-lock",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-global-executor"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "05b1b633a2115cd122d73b955eadd9916c18c8f510ec9cd1686404c60ad1c29c"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "blocking",
+ "futures-lite",
+ "once_cell",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener 5.4.1",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-net"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b948000fad4873c1c9339d60f2623323a0cfd3816e5181033c6a5cb68b2accf7"
+dependencies = [
+ "async-io",
+ "blocking",
+ "futures-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener 5.4.1",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-std"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8e079a4ab67ae52b7403632e4618815d6db36d2a010cfe41b02c1b1578f93b"
+dependencies = [
+ "async-channel 1.9.0",
+ "async-global-executor",
+ "async-io",
+ "async-lock",
+ "crossbeam-utils",
+ "futures-channel",
+ "futures-core",
+ "futures-io",
+ "futures-lite",
+ "gloo-timers",
+ "kv-log-macro",
+ "log",
+ "memchr",
+ "once_cell",
+ "pin-project-lite",
+ "pin-utils",
+ "slab",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
 name = "async-stream"
 version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -172,6 +387,12 @@ dependencies = [
  "quote",
  "syn",
 ]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
 
 [[package]]
 name = "async-trait"
@@ -292,6 +513,28 @@ name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
+
+[[package]]
+name = "block2"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c132eebf10f5cad5289222520a4a058514204aed6d791f1cf4fe8088b82d15f"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel 2.5.0",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bollard"
@@ -490,6 +733,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "console"
 version = "0.16.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -558,6 +810,20 @@ name = "crossbeam-utils"
 version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "dark-light"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18e1a09f280e29a8b00bc7e81eca5ac87dca0575639c9422a5fa25a07bb884b8"
+dependencies = [
+ "ashpd",
+ "async-std",
+ "objc2",
+ "objc2-foundation",
+ "web-sys",
+ "winreg",
+]
 
 [[package]]
 name = "darling"
@@ -671,6 +937,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "env_filter"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -714,6 +1007,33 @@ checksum = "de48cc4d1c1d97a20fd819def54b890cadde72ed3ad0c614822a0a433361be96"
 dependencies = [
  "cfg-if",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "event-listener"
+version = "2.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0206175f82b8d6bf6652ff7d71a1e27fd2e4efde587fd368662814d6ec1d9ce0"
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener 5.4.1",
+ "pin-project-lite",
 ]
 
 [[package]]
@@ -853,6 +1173,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -936,6 +1269,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "gloo-timers"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbb143cf96099802033e0d4f4963b19fd2e0b728bcf076cd9cf7f6634f092994"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "h2"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -980,6 +1325,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -1373,6 +1724,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "kv-log-macro"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de8b303297635ad57c9f5059fd9cee7a47f8e8daa09df0fcd07dd39fb22977f"
+dependencies = [
+ "log",
+]
+
+[[package]]
 name = "leb128fmt"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1416,6 +1776,9 @@ name = "log"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "113b30b4cd05f7c06868fdb2854f66a7b9fece9a48425351cd532e810d74024f"
+dependencies = [
+ "value-bag",
+]
 
 [[package]]
 name = "matchit"
@@ -1428,6 +1791,15 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "mime"
@@ -1536,6 +1908,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc-sys"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdb91bdd390c7ce1a8607f35f3ca7151b65afc0ff5ff3b34fa350f7d7c7e4310"
+
+[[package]]
+name = "objc2"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46a785d4eeff09c14c487497c162e92766fbb3e4059a71840cecc03d9a50b804"
+dependencies = [
+ "objc-sys",
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee638a5da3799329310ad4cfa62fbf045d5f56e3ef5ba4149e7452dcf89d5a8"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1558,6 +1964,22 @@ name = "option-ext"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parse-display"
@@ -1617,6 +2039,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1673,6 +2126,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.12+spec-1.1.0",
 ]
 
 [[package]]
@@ -1739,11 +2201,22 @@ checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "libc",
+ "rand_chacha 0.3.1",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
 dependencies = [
- "rand_chacha",
+ "rand_chacha 0.9.0",
  "rand_core 0.9.5",
 ]
 
@@ -1760,12 +2233,31 @@ dependencies = [
 
 [[package]]
 name = "rand_chacha"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6c10a63a0fa32252be49d21e7709d4d4baf8d231c2dbce1eaa8141b9b127d88"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "rand_chacha"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
  "rand_core 0.9.5",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+dependencies = [
+ "getrandom 0.2.17",
 ]
 
 [[package]]
@@ -2546,7 +3038,7 @@ dependencies = [
  "serde",
  "serde_spanned 0.6.9",
  "toml_datetime 0.6.11",
- "toml_edit",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -2594,6 +3086,18 @@ dependencies = [
  "toml_datetime 0.6.11",
  "toml_write",
  "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.12+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2153edc6955a6c354fad8f5efd38b6a8769bdccf9fe50f8e1329f81b0baa5d7"
+dependencies = [
+ "indexmap 2.14.0",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.3",
 ]
 
 [[package]]
@@ -2726,6 +3230,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "uncased"
 version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2823,6 +3338,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "js-sys",
+ "serde_core",
+ "wasm-bindgen",
+]
+
+[[package]]
+name = "value-bag"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ba6f5989077681266825251a52748b8c1d8a4ad098cc37e440103d0ea717fc0"
+
+[[package]]
 name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2882,6 +3414,16 @@ dependencies = [
  "rustversion",
  "wasm-bindgen-macro",
  "wasm-bindgen-shared",
+]
+
+[[package]]
+name = "wasm-bindgen-futures"
+version = "0.4.72"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9473dbd2991ae90b6291c3c32c30c6187ac49aa32f9905d1cce280ec1e110b0f"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -2948,6 +3490,16 @@ dependencies = [
  "hashbrown 0.15.5",
  "indexmap 2.14.0",
  "semver",
+]
+
+[[package]]
+name = "web-sys"
+version = "0.3.99"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d621441cfc37b84979402712047321980c178f299193a3589d05b99e8763436"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -3052,11 +3604,20 @@ dependencies = [
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3070,19 +3631,40 @@ dependencies = [
 
 [[package]]
 name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
+]
+
+[[package]]
+name = "windows-targets"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm",
- "windows_aarch64_msvc",
- "windows_i686_gnu",
+ "windows_aarch64_gnullvm 0.52.6",
+ "windows_aarch64_msvc 0.52.6",
+ "windows_i686_gnu 0.52.6",
  "windows_i686_gnullvm",
- "windows_i686_msvc",
- "windows_x86_64_gnu",
- "windows_x86_64_gnullvm",
- "windows_x86_64_msvc",
+ "windows_i686_msvc 0.52.6",
+ "windows_x86_64_gnu 0.52.6",
+ "windows_x86_64_gnullvm 0.52.6",
+ "windows_x86_64_msvc 0.52.6",
 ]
+
+[[package]]
+name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
@@ -3092,9 +3674,21 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3110,9 +3704,21 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -3122,9 +3728,21 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -3148,6 +3766,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 dependencies = [
  "memchr",
+]
+
+[[package]]
+name = "winreg"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
+dependencies = [
+ "cfg-if",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -3299,6 +3927,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee682d202a77e4a9f3b2c2bdf48a7b28af5c08c34ddf66f98c93e5e39464285"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener 5.4.1",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 1.0.3",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adf1bd45a81a103745b1757754762a26e8cd01e4532e4d6c8ec431624b80d1d6"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7074f3e50b894eac91750142016d30d0a89be8e67dbfd9704fb875825760e52d"
+dependencies = [
+ "serde",
+ "winnow 1.0.3",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3389,9 +4078,11 @@ name = "zsh-patina"
 version = "1.7.0"
 dependencies = [
  "anyhow",
+ "arc-swap",
  "askama",
  "clap",
  "clap_complete",
+ "dark-light",
  "dirs",
  "env_logger",
  "figment",
@@ -3413,4 +4104,45 @@ dependencies = [
  "textwrap",
  "tokio",
  "toml 1.1.2+spec-1.1.0",
+]
+
+[[package]]
+name = "zvariant"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a192a0bde63360d77a7523c833d4b4ce6070a927e2c53246e4c540b1a3e27be0"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "url",
+ "winnow 1.0.3",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90bc6cde9c01c511074be97f7ccb6c19d0da89e3f8662e812e999dcfd4638737"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e8535915cfa75547e559d8c68e8139909a4aeee076831e4ef7fc59d8172c4d6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 1.0.3",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,9 +22,11 @@ opt-level = 3
 
 [dependencies]
 anyhow = "1.0.102"
+arc-swap = "1.9.1"
 askama = "0.16.0"
 clap = { version = "4.5.60", features = ["derive", "wrap_help"] }
 clap_complete = "4.6.0"
+dark-light = "2.0.0"
 dirs = "6.0.0"
 env_logger = { version = "0.11.10", default-features = false, features = ["humantime"]}
 figment = { version = "0.10.19", features = ["toml"] }

--- a/README.md
+++ b/README.md
@@ -260,8 +260,11 @@ If the file doesn't exist at either location, the plugin uses the default settin
 
 ```toml
 [highlighting]
-# Either the name of a built-in theme (e.g. `"simple"`, `"patina"`) or a string
-# in the form `"file:/path/mytheme.toml"` pointing to a custom theme toml file.
+# The name of a built-in theme (e.g. `"simple"`, `"patina"`), a string in the
+# form `"file:/path/mytheme.toml"` pointing to a custom theme toml file, or an
+# adaptive theme that follows the system appearance (see "Automatic light/dark
+# theme switching" below), e.g.
+# `{ light = "catppuccin-latte", dark = "catppuccin-mocha" }`.
 theme = "patina"
 
 # Enable or disable dynamic highlighting. Can be `true` or `false` ...
@@ -297,6 +300,29 @@ timeout_ms = 500
 ```shell
 zsh-patina restart
 ```
+
+### Automatic light/dark theme switching
+
+zsh-patina can automatically follow the system appearance and switch between a
+light and a dark theme. Configure the `theme` option with a table that holds a
+`light` and a `dark` theme:
+
+```toml
+[highlighting]
+theme = { light = "catppuccin-latte", dark = "catppuccin-mocha" }
+```
+
+Both entries accept anything the `theme` option normally accepts, including
+custom theme files, e.g. `{ light = "file:/path/light.toml", dark = "nord" }`.
+
+The daemon detects appearance changes on its own — there is no need to restart
+it or reload your shell. After you toggle your system between light and dark
+mode (on macOS, *System Settings → Appearance*), the highlighting follows
+within a few seconds.
+
+Appearance detection works on macOS, Windows, and Linux (the latter via the
+XDG desktop portal). Where the appearance cannot be determined, adaptive themes
+fall back to their `light` variant.
 
 ### Custom precommands
 

--- a/src/appearance.rs
+++ b/src/appearance.rs
@@ -1,0 +1,12 @@
+//! Detection of the operating system's light/dark appearance. This is used to
+//! resolve adaptive themes (see [`crate::theme::ThemeConfig`]).
+
+/// Returns `true` if the system is currently using a dark appearance.
+///
+/// This uses the `dark-light` crate, which reads the OS appearance setting on
+/// macOS, Windows, and Linux (the latter via the XDG desktop portal). If the
+/// appearance cannot be determined, this returns `false` so adaptive themes
+/// fall back to their light variant.
+pub fn is_dark_mode() -> bool {
+    matches!(dark_light::detect(), Ok(dark_light::Mode::Dark))
+}

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -51,8 +51,11 @@ pub fn check_config(config: &Config) -> Result<()> {
     // configuration is parseable. Otherwise, we would not have a `config`
     // object.
 
-    // check if we can load the custom theme and if it's syntax is OK
-    Theme::load(&config.highlighting.theme)?;
+    // check if we can load the custom theme(s) and if their syntax is OK. For
+    // an adaptive theme, both the light and the dark variant are checked.
+    for source in config.highlighting.theme.sources() {
+        Theme::load(source)?;
+    }
 
     Ok(())
 }
@@ -194,18 +197,21 @@ fn check_zsh_version() -> (String, MessageType) {
     }
 }
 
-/// Check if the configured theme can be loaded
+/// Check if the configured theme can be loaded. For an adaptive theme, both the
+/// light and the dark variant are loaded.
 fn check_theme(config: &Config) -> (String, MessageType) {
-    match Theme::load(&config.highlighting.theme) {
-        Err(e) => (
-            format!("Theme could not be loaded\n\n{e:?}"),
-            MessageType::Error,
-        ),
-        Ok(_) => (
-            format!("Theme `{}' loaded successfully.", config.highlighting.theme),
-            MessageType::Success,
-        ),
+    for source in config.highlighting.theme.sources() {
+        if let Err(e) = Theme::load(source) {
+            return (
+                format!("Theme could not be loaded\n\n{e:?}"),
+                MessageType::Error,
+            );
+        }
     }
+    (
+        format!("Theme `{}' loaded successfully.", config.highlighting.theme),
+        MessageType::Success,
+    )
 }
 
 /// Check if zsh-patina is active in the current shell session

--- a/src/commands/listthemes.rs
+++ b/src/commands/listthemes.rs
@@ -9,7 +9,7 @@ use crate::{
     color::Color,
     config::{Config, HighlightingConfig},
     highlighting::{Highlighter, HighlightingRequest, Span, SpanStyle},
-    theme::{Style, Theme, ThemeSource},
+    theme::{Style, Theme, ThemeConfig, ThemeSource},
 };
 
 /// Convert a style to a termcolor ColorSpec
@@ -110,7 +110,7 @@ where
     W: WriteColor,
 {
     let config = HighlightingConfig {
-        theme: theme_source,
+        theme: ThemeConfig::Single(theme_source),
         timeout: Duration::from_secs(3600),
         ..Default::default()
     };
@@ -163,10 +163,19 @@ pub fn list_themes(config: &Config) -> Result<()> {
     let bufwtr = BufferWriter::stdout(ColorChoice::Auto);
     let mut buffer = bufwtr.buffer();
 
+    let config_sources = config.highlighting.theme.sources();
+    let default_theme = HighlightingConfig::default().theme;
+    let default_sources = default_theme.sources();
+
     for mut theme in ThemeSource::iter() {
         if matches!(theme, ThemeSource::File(_)) {
-            if matches!(config.highlighting.theme, ThemeSource::File(_)) {
-                theme = config.highlighting.theme.clone();
+            // The iterator yields a single placeholder `file:` entry. Substitute
+            // it with the user's custom theme file, if they configured one.
+            if let Some(&file_source) = config_sources
+                .iter()
+                .find(|s| matches!(s, ThemeSource::File(_)))
+            {
+                theme = file_source.clone();
             } else {
                 continue;
             }
@@ -180,8 +189,8 @@ pub fn list_themes(config: &Config) -> Result<()> {
         write!(buffer, "{theme}")?;
         buffer.set_color(ColorSpec::new().set_fg(Some(TermColor::Rgb(160, 160, 160))))?;
 
-        let active = theme == config.highlighting.theme;
-        let default = theme == HighlightingConfig::default().theme;
+        let active = config_sources.contains(&&theme);
+        let default = default_sources.contains(&&theme);
 
         if active || default {
             write!(buffer, " (")?;

--- a/src/commands/tokenize.rs
+++ b/src/commands/tokenize.rs
@@ -15,7 +15,12 @@ use crate::{
 /// Tokenize an input file and print the identified tokens to stdout. If the
 /// input file is `None`, read from stdin.
 pub fn tokenize(config: &Config, input_file: &Option<String>) -> Result<()> {
-    let theme = Theme::load(&config.highlighting.theme)?;
+    let theme = Theme::load(
+        config
+            .highlighting
+            .theme
+            .resolve(crate::appearance::is_dark_mode()),
+    )?;
 
     // read input
     let input = if let Some(input_file) = input_file {

--- a/src/config.rs
+++ b/src/config.rs
@@ -7,7 +7,7 @@ use serde::{
     ser::SerializeMap,
 };
 
-use crate::theme::ThemeSource;
+use crate::theme::{ThemeConfig, ThemeSource};
 
 #[derive(Serialize, Deserialize, Default)]
 #[serde(deny_unknown_fields)]
@@ -15,13 +15,15 @@ pub struct Config {
     pub highlighting: HighlightingConfig,
 }
 
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct HighlightingConfig {
     /// Either the name of a built-in theme (`"simple"`, `"patina"`,
-    /// `"lavender"`) or a string in the form `"file:mytheme.toml"` pointing to
-    /// a custom theme toml file.
-    pub theme: ThemeSource,
+    /// `"lavender"`), a string in the form `"file:mytheme.toml"` pointing to a
+    /// custom theme toml file, or an adaptive table that follows the operating
+    /// system's light/dark appearance, e.g.
+    /// `{ light = "catppuccin-latte", dark = "catppuccin-mocha" }`.
+    pub theme: ThemeConfig,
 
     /// If enabled, zsh-patina will highlight callables (aliases, builtins,
     /// commands, and functions) as well as files and directories dynamically
@@ -99,7 +101,7 @@ fn deserialize_duration_ms<'de, D: Deserializer<'de>>(d: D) -> Result<Duration, 
 impl Default for HighlightingConfig {
     fn default() -> Self {
         Self {
-            theme: ThemeSource::Patina,
+            theme: ThemeConfig::Single(ThemeSource::Patina),
             dynamic: DynamicConfig::default(),
             max_line_length: 20000,
             timeout: Duration::from_millis(500),
@@ -304,7 +306,7 @@ pub enum PrecommandArg {
 ///
 /// At least one of `short` or `long` should be set. Both may be set if the
 /// option has both a short and a long form.
-#[derive(Serialize, Deserialize, Default)]
+#[derive(Serialize, Deserialize, Default, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PrecommandOption {
     /// The short form of the option, without the leading dash (e.g. `"u"` for
@@ -343,7 +345,7 @@ pub struct PrecommandOption {
 ///     { short = "n", arg = "none" },
 /// ]
 /// ```
-#[derive(Serialize, Deserialize)]
+#[derive(Serialize, Deserialize, Clone)]
 #[serde(deny_unknown_fields)]
 pub struct PrecommandConfig {
     /// The name of the precommand as it appears in the shell

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result, bail};
+use arc_swap::ArcSwap;
 use askama::Template;
 use rayon::ThreadPoolBuilder;
 use rustc_hash::{FxHashMap, FxHashSet};
@@ -1330,18 +1331,60 @@ fn start_daemon_internal(
 
     let pool = ThreadPoolBuilder::new().num_threads(4).build().unwrap();
 
-    // initialize highlighter
-    let highlighter = Arc::new(HighlighterBuilder::new(&config.highlighting).build()?);
+    // Own a copy of the highlighting configuration so the appearance watcher
+    // thread can rebuild the highlighter for its whole lifetime.
+    let highlighting = Arc::new(config.highlighting.clone());
+
+    // Initialize the highlighter. It is held in an `ArcSwap` so the appearance
+    // watcher can atomically replace it when the system switches between light
+    // and dark mode. Connection workers take a lock-free snapshot for each
+    // request, so an in-flight request finishes with the theme it started with.
+    let highlighter = Arc::new(ArcSwap::from_pointee(
+        HighlighterBuilder::new(&highlighting).build()?,
+    ));
 
     // highlight something to make sure everything is loaded - do this in a
     // background task to not delay the main thread
-    let init_highlighter = Arc::clone(&highlighter);
+    let init_highlighter = highlighter.load_full();
     pool.spawn(move || {
         let _ = init_highlighter.highlight(
             "echo Welcome to zsh-patina!",
             &HighlightingRequest::default(),
         );
     });
+
+    // For adaptive themes, watch the system appearance and swap the highlighter
+    // when it changes. Polling the appearance is cheap, so a 5 second interval
+    // is negligible.
+    if highlighting.theme.is_adaptive() {
+        let highlighting = Arc::clone(&highlighting);
+        let highlighter = Arc::clone(&highlighter);
+        std::thread::spawn(move || {
+            let mut current_dark_mode = crate::appearance::is_dark_mode();
+            loop {
+                std::thread::sleep(Duration::from_secs(5));
+
+                let dark_mode = crate::appearance::is_dark_mode();
+                if dark_mode == current_dark_mode {
+                    continue;
+                }
+                current_dark_mode = dark_mode;
+
+                match HighlighterBuilder::new(&highlighting).build() {
+                    Ok(new_highlighter) => {
+                        highlighter.store(Arc::new(new_highlighter));
+                        log::info!(
+                            "System appearance changed; switched to {} theme.",
+                            if dark_mode { "dark" } else { "light" }
+                        );
+                    }
+                    Err(e) => {
+                        log::error!("Failed to rebuild highlighter after appearance change: {e}");
+                    }
+                }
+            }
+        });
+    }
 
     // bind the Unix domain socket
     let listener = UnixListener::bind(&socket_path)
@@ -1367,7 +1410,10 @@ fn start_daemon_internal(
                 stream.set_read_timeout(Some(Duration::from_secs(1)))?;
                 stream.set_write_timeout(Some(Duration::from_secs(1)))?;
 
-                let highlighter = Arc::clone(&highlighter);
+                // Take a lock-free snapshot of the current highlighter. If the
+                // appearance watcher swaps in a new one, in-flight connections
+                // keep using the snapshot they started with.
+                let highlighter = highlighter.load_full();
                 pool.spawn(|| {
                     log::debug!("New connection ...");
 

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -23,7 +23,7 @@ use crate::{
         historyexpansion::HistoryExpanded,
         syntax::load_syntax_set,
     },
-    theme::{ScopeMapping, Theme, ThemeSource},
+    theme::{ScopeMapping, Theme},
 };
 
 fn mix_spans(base: Vec<Span>, mut mixins: Vec<Span>) -> Vec<Span> {
@@ -238,34 +238,16 @@ impl Highlighter {
     pub fn new(config: &HighlightingConfig, home_dir: String) -> Result<Self> {
         let syntax_set = load_syntax_set(&config.precommands);
 
-        let theme = Theme::load(&config.theme)?;
+        // Resolve adaptive themes to the concrete source for the current system
+        // appearance. The daemon rebuilds the highlighter when the appearance
+        // changes, so reading it here is sufficient.
+        let theme_source = config.theme.resolve(crate::appearance::is_dark_mode());
+
+        let theme = Theme::load(theme_source)?;
         let scope_mapping = ScopeMapping::new(&theme);
-        let syntect_theme =
-            theme
-                .to_syntect(&scope_mapping)
-                .with_context(|| match &config.theme {
-                    ThemeSource::CatppuccinFrappe => {
-                        "Failed to parse catppuccin-frappe theme".to_string()
-                    }
-                    ThemeSource::CatppuccinLatte => {
-                        "Failed to parse catppuccin-latte theme".to_string()
-                    }
-                    ThemeSource::CatppuccinMacchiato => {
-                        "Failed to parse catppuccin-macchiato theme".to_string()
-                    }
-                    ThemeSource::CatppuccinMocha => {
-                        "Failed to parse catppuccin-mocha theme".to_string()
-                    }
-                    ThemeSource::Classic => "Failed to parse classic theme".to_string(),
-                    ThemeSource::Kanagawa => "Failed to parse kanagawa theme".to_string(),
-                    ThemeSource::Lavender => "Failed to parse lavender theme".to_string(),
-                    ThemeSource::Nord => "Failed to parse nord theme".to_string(),
-                    ThemeSource::Patina => "Failed to parse default theme".to_string(),
-                    ThemeSource::Simple => "Failed to parse simple theme".to_string(),
-                    ThemeSource::Solarized => "Failed to parse solarized theme".to_string(),
-                    ThemeSource::TokyoNight => "Failed to parse tokyonight theme".to_string(),
-                    ThemeSource::File(path) => format!("Failed to parse theme file `{path}'"),
-                })?;
+        let syntect_theme = theme
+            .to_syntect(&scope_mapping)
+            .with_context(|| format!("Failed to parse theme `{theme_source}'"))?;
 
         let mut callable_choices: FxHashMap<CallableType, StaticStyle> = FxHashMap::default();
         if let Some(alias_style) = resolve_static_style(DYNAMIC_CALLABLE_ALIAS, &theme) {
@@ -549,6 +531,7 @@ pub mod tests {
     use crate::config::DynamicConfig;
 
     use super::*;
+    use crate::theme::{ThemeConfig, ThemeSource};
     use anyhow::Result;
     use insta::assert_snapshot;
     use pretty_assertions::assert_eq;
@@ -557,7 +540,9 @@ pub mod tests {
 
     pub fn test_config() -> HighlightingConfig {
         HighlightingConfig {
-            theme: ThemeSource::File(concat!(env!("OUT_DIR"), "/test_theme.toml").to_string()),
+            theme: ThemeConfig::Single(ThemeSource::File(
+                concat!(env!("OUT_DIR"), "/test_theme.toml").to_string(),
+            )),
             timeout: Duration::from_secs(3600),
             ..Default::default()
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -14,6 +14,7 @@ use crate::{
     daemon::{activate, start_daemon, status_daemon, stop_daemon},
 };
 
+mod appearance;
 mod color;
 mod commands;
 pub mod config;

--- a/src/theme.rs
+++ b/src/theme.rs
@@ -9,6 +9,7 @@ use rustc_hash::FxHashMap;
 use serde::{
     Deserialize, Deserializer, Serialize, Serializer,
     de::{Error, MapAccess, Visitor, value::MapAccessDeserializer},
+    ser::SerializeMap,
 };
 use strum::EnumIter;
 use syntect::{
@@ -47,13 +48,11 @@ impl Serialize for ThemeSource {
     }
 }
 
-impl<'de> Deserialize<'de> for ThemeSource {
-    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
-    where
-        D: Deserializer<'de>,
-    {
-        let s = String::deserialize(deserializer)?;
-        match s.as_str() {
+impl ThemeSource {
+    /// Parse a single theme source from a string such as `"nord"` or
+    /// `"file:mytheme.toml"`. Returns a human-readable error message on failure.
+    fn parse(s: &str) -> std::result::Result<Self, String> {
+        match s {
             "catppuccin-frappe" => Ok(ThemeSource::CatppuccinFrappe),
             "catppuccin-latte" => Ok(ThemeSource::CatppuccinLatte),
             "catppuccin-macchiato" => Ok(ThemeSource::CatppuccinMacchiato),
@@ -68,11 +67,144 @@ impl<'de> Deserialize<'de> for ThemeSource {
             "tokyonight" => Ok(ThemeSource::TokyoNight),
             _ if s.starts_with("file:") => Ok(ThemeSource::File(
                 shellexpand::full(&s[5..])
-                    .map_err(D::Error::custom)?
+                    .map_err(|e| e.to_string())?
                     .to_string(),
             )),
-            _ => Err(Error::custom(format!("Unsupported theme source: {s}"))),
+            _ => Err(format!("Unsupported theme source: {s}")),
         }
+    }
+}
+
+impl<'de> Deserialize<'de> for ThemeSource {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        let s = String::deserialize(deserializer)?;
+        ThemeSource::parse(&s).map_err(Error::custom)
+    }
+}
+
+/// The `theme` setting in the configuration file. This is either a single
+/// [`ThemeSource`] (a plain string) or an adaptive pair that follows the
+/// operating system's light/dark appearance, expressed as a table:
+///
+/// ```toml
+/// theme = "catppuccin-latte"
+///
+/// # or, adaptive:
+/// theme = { light = "catppuccin-latte", dark = "catppuccin-mocha" }
+/// ```
+#[derive(Clone, PartialEq, Eq, Debug)]
+pub enum ThemeConfig {
+    Single(ThemeSource),
+    Adaptive {
+        light: ThemeSource,
+        dark: ThemeSource,
+    },
+}
+
+impl ThemeConfig {
+    /// Resolve to the concrete theme source that should be used for the given
+    /// appearance. For a single theme, the appearance is ignored.
+    pub fn resolve(&self, dark_mode: bool) -> &ThemeSource {
+        match self {
+            ThemeConfig::Single(source) => source,
+            ThemeConfig::Adaptive { light, dark } => {
+                if dark_mode {
+                    dark
+                } else {
+                    light
+                }
+            }
+        }
+    }
+
+    /// All concrete theme sources referenced by this configuration (one for a
+    /// single theme, two for an adaptive theme).
+    pub fn sources(&self) -> Vec<&ThemeSource> {
+        match self {
+            ThemeConfig::Single(source) => vec![source],
+            ThemeConfig::Adaptive { light, dark } => vec![light, dark],
+        }
+    }
+
+    /// Whether this configuration switches themes based on the system
+    /// appearance.
+    pub fn is_adaptive(&self) -> bool {
+        matches!(self, ThemeConfig::Adaptive { .. })
+    }
+}
+
+impl Display for ThemeConfig {
+    fn fmt(&self, f: &mut Formatter) -> fmt::Result {
+        match self {
+            ThemeConfig::Single(source) => write!(f, "{source}"),
+            ThemeConfig::Adaptive { light, dark } => write!(f, "light: {light}, dark: {dark}"),
+        }
+    }
+}
+
+impl Serialize for ThemeConfig {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: Serializer,
+    {
+        match self {
+            ThemeConfig::Single(source) => source.serialize(serializer),
+            ThemeConfig::Adaptive { light, dark } => {
+                let mut map = serializer.serialize_map(Some(2))?;
+                map.serialize_entry("light", light)?;
+                map.serialize_entry("dark", dark)?;
+                map.end()
+            }
+        }
+    }
+}
+
+impl<'de> Deserialize<'de> for ThemeConfig {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct StringOrTable;
+
+        impl<'de> Visitor<'de> for StringOrTable {
+            type Value = ThemeConfig;
+
+            fn expecting(&self, formatter: &mut Formatter) -> fmt::Result {
+                formatter.write_str("a theme name, or a table with `light` and `dark` theme names")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<ThemeConfig, E>
+            where
+                E: serde::de::Error,
+            {
+                ThemeSource::parse(value)
+                    .map(ThemeConfig::Single)
+                    .map_err(E::custom)
+            }
+
+            fn visit_map<M>(self, map: M) -> Result<ThemeConfig, M::Error>
+            where
+                M: MapAccess<'de>,
+            {
+                #[derive(Deserialize)]
+                #[serde(deny_unknown_fields)]
+                struct Helper {
+                    light: ThemeSource,
+                    dark: ThemeSource,
+                }
+
+                let h = Helper::deserialize(MapAccessDeserializer::new(map))?;
+                Ok(ThemeConfig::Adaptive {
+                    light: h.light,
+                    dark: h.dark,
+                })
+            }
+        }
+
+        deserializer.deserialize_any(StringOrTable)
     }
 }
 
@@ -399,6 +531,95 @@ mod tests {
     fn load_builtin_without_metadata() {
         let theme = Theme::load(&ThemeSource::Patina).unwrap();
         assert!(theme.resolve("comment").is_some());
+    }
+
+    #[derive(serde::Serialize, serde::Deserialize)]
+    struct ThemeWrapper {
+        theme: ThemeConfig,
+    }
+
+    /// Deserialize a `ThemeConfig` from the `theme = ...` line of a TOML config,
+    /// exercising the same path the real configuration loader uses.
+    fn parse_theme(toml_line: &str) -> std::result::Result<ThemeConfig, toml::de::Error> {
+        toml::from_str::<ThemeWrapper>(toml_line).map(|w| w.theme)
+    }
+
+    #[test]
+    fn theme_config_parses_single() {
+        let config = parse_theme(r#"theme = "nord""#).unwrap();
+        assert_eq!(config, ThemeConfig::Single(ThemeSource::Nord));
+        assert!(!config.is_adaptive());
+        assert_eq!(config.resolve(false), &ThemeSource::Nord);
+        assert_eq!(config.resolve(true), &ThemeSource::Nord);
+        assert_eq!(config.to_string(), "nord");
+    }
+
+    #[test]
+    fn theme_config_parses_adaptive_table() {
+        let config =
+            parse_theme(r#"theme = { light = "catppuccin-latte", dark = "catppuccin-mocha" }"#)
+                .unwrap();
+        assert_eq!(
+            config,
+            ThemeConfig::Adaptive {
+                light: ThemeSource::CatppuccinLatte,
+                dark: ThemeSource::CatppuccinMocha,
+            }
+        );
+        assert!(config.is_adaptive());
+        assert_eq!(config.resolve(false), &ThemeSource::CatppuccinLatte);
+        assert_eq!(config.resolve(true), &ThemeSource::CatppuccinMocha);
+        assert_eq!(
+            config.sources(),
+            vec![&ThemeSource::CatppuccinLatte, &ThemeSource::CatppuccinMocha]
+        );
+    }
+
+    #[test]
+    fn theme_config_adaptive_key_order_independent() {
+        let config = parse_theme(r#"theme = { dark = "nord", light = "solarized" }"#).unwrap();
+        assert_eq!(
+            config,
+            ThemeConfig::Adaptive {
+                light: ThemeSource::Solarized,
+                dark: ThemeSource::Nord,
+            }
+        );
+    }
+
+    #[test]
+    fn theme_config_round_trips_through_toml() {
+        for config in [
+            ThemeConfig::Single(ThemeSource::Nord),
+            ThemeConfig::Adaptive {
+                light: ThemeSource::Nord,
+                dark: ThemeSource::Patina,
+            },
+        ] {
+            let serialized = toml::to_string(&ThemeWrapper {
+                theme: config.clone(),
+            })
+            .unwrap();
+            assert_eq!(parse_theme(&serialized).unwrap(), config);
+        }
+    }
+
+    #[test]
+    fn theme_config_rejects_missing_variant() {
+        assert!(parse_theme(r#"theme = { light = "nord" }"#).is_err());
+        assert!(parse_theme(r#"theme = { dark = "nord" }"#).is_err());
+    }
+
+    #[test]
+    fn theme_config_rejects_unknown_field_and_unknown_theme() {
+        // unknown key in the adaptive table
+        assert!(
+            parse_theme(r#"theme = { light = "nord", dark = "patina", bright = "x" }"#).is_err()
+        );
+        // unknown theme name in the table
+        assert!(parse_theme(r#"theme = { light = "does-not-exist", dark = "nord" }"#).is_err());
+        // unknown single theme name
+        assert!(parse_theme(r#"theme = "does-not-exist""#).is_err());
     }
 
     #[test]


### PR DESCRIPTION
## What

Adds support for **adaptive themes** that follow the operating system's light/dark appearance, switching live when the system toggles between the two.

The `theme` option now accepts either a plain theme name (as before) or a table naming a light and a dark variant:

```toml
# single theme (unchanged)
theme = "catppuccin-latte"

# adaptive
theme = { light = "catppuccin-latte", dark = "catppuccin-mocha" }
```

For an adaptive theme the daemon resolves the variant matching the current appearance and swaps the active highlighter when the appearance changes — no restart or config edit needed.

Closes #59.

## Why

Anyone whose terminal follows the system light/dark schedule currently has to pick a single static theme — a dark theme washes out in light mode and vice versa, and the only fix is editing the config and restarting the shell. This makes the theme follow the system automatically.

## Design notes (per the discussion in #59)

- **Table syntax.** An adaptive theme is a `{ light, dark }` table, consistent with how other config options (e.g. `dynamic`) already accept either a scalar or a table. A plain string still selects a single theme.
- **System appearance, not terminal background.** Reading the terminal background isn't possible from the daemon (it detaches from the controlling terminal — stdin/stdout/stderr go to `/dev/null`), so detection uses the OS appearance via the [`dark-light`](https://crates.io/crates/dark-light) crate. The feature is opt-in, aimed at setups where the terminal tracks the system appearance.

> **Note on dependencies:** `dark-light` 2.0 is fairly heavy — on macOS it's just the `objc2` bindings, but on Linux it pulls the `zbus`/`ashpd` XDG-portal stack (and `windows-sys` on Windows), so `Cargo.lock` grows by ~65 transitive crates. Most of that is inherent to cross-platform appearance detection — the Linux side has to query the desktop portal over D-Bus. It stays within the current 1.88 MSRV (the tightest new dependency is `zbus` at 1.87). This was the approach we settled on in #59; flagging the footprint here in case you'd like to weigh it before merging.

## How

- **`src/theme.rs`** — `ThemeConfig` (`Single` / `Adaptive`) deserializes from either a string or a `{ light, dark }` table via a `deserialize_any` visitor, mirroring the existing `DynamicConfig` pattern. `ThemeSource` stays a concrete, loadable theme.
- **`src/appearance.rs`** (new) — `is_dark_mode()` wraps `dark_light::detect()`, which reads the OS appearance on macOS, Windows, and Linux (the latter via the XDG desktop portal). On macOS it reads `AppleInterfaceStyle` from `NSUserDefaults` in-process. If the appearance can't be determined, it falls back to the light variant.
- **`src/daemon.rs`** — for adaptive themes the daemon spawns a watcher thread that polls the appearance every 5 s and atomically hot-swaps the highlighter via `ArcSwap` (in-flight requests finish with the theme they started with).
- **`README.md`** — documents the new syntax and behavior.

## Testing

- `cargo fmt --check`, `cargo clippy`, and `cargo test` all clean (123 tests pass; the only clippy warning is the pre-existing `handle_connection_v1` deprecation on `main`).
- New unit tests cover string and table deserialization, key-order independence, TOML round-tripping, and rejection of missing/unknown fields, all through the real config path.
- Dogfooded the daemon across appearance flips — the watcher detects both directions and rebuilds the highlighter each time:

  ```
  [INFO src/daemon.rs:1376 ThreadId(6)] System appearance changed; switched to dark theme.
  [INFO src/daemon.rs:1376 ThreadId(6)] System appearance changed; switched to light theme.
  ```
