### PR TITLE
Resolved named directories with protocol version 3

### DIFF
--- a/docs/protocol.adoc
+++ b/docs/protocol.adoc
@@ -1,4 +1,4 @@
-= zsh-patina -- Client/Daemon Communication Protocol v2
+= zsh-patina -- Client/Daemon Communication Protocol v3
 :toc: left
 :toc-title: Contents
 :sectnums:
@@ -7,7 +7,7 @@
 
 == Introduction
 
-zsh-patina provides interactive syntax highlighting for the Zsh line editor (ZLE). On each keypress, a Zsh function (the _client_) sends the current editing buffer to a persistent Rust daemon over a Unix domain socket. The daemon performs syntax analysis and returns a list of highlight spans. This document specifies version 2 of the communication protocol between the zsh-patina client and the daemon.
+zsh-patina provides interactive syntax highlighting for the Zsh line editor (ZLE). On each keypress, a Zsh function (the _client_) sends the current editing buffer to a persistent Rust daemon over a Unix domain socket. The daemon performs syntax analysis and returns a list of highlight spans. This document specifies version 3 of the communication protocol between the zsh-patina client and the daemon.
 
 == Conventions
 
@@ -40,7 +40,7 @@ The ABNF syntax used in this document is defined in RFC 5234.
 [[versioning]]
 == Protocol Version Number
 
-The version number carried in the `VER` header field (see <<request-metadata>>) identifies the major revision of this protocol. The current version is `2`.
+The version number carried in the `VER` header field (see <<request-metadata>>) identifies the major revision of this protocol. The current version is `3`.
 
 The version number is a major version only. New fields, commands, or response lines MAY be added to this specification without incrementing the version number, provided the addition is backwards-compatible. An addition is considered backwards-compatible if a sender transmitting the new information to a receiver that does not implement it causes no degradation of existing functionality--that is, the receiver silently ignores the unknown element. Similarly, the sender transmitting the new information MUST NOT be affected by the receiver ignoring it.
 
@@ -338,6 +338,13 @@ The client MUST respond with one LF-terminated answer line per body line, in ord
 |`a<body>` |Alias. The character `a` is immediately followed by the alias expansion body (no separator). An empty body (`a` followed immediately by LF) is valid and represents an alias expanding to the empty string. The body MUST be percent-encoded per <<encoding-values>>.
 |===
 
+[[named-directory-query]]
+====== Named Directory Query (`NMD`)
+
+The daemon sends a `?CMD=NMD` query to ask the client to resolve named directories in the current shell environment. Each body line is one named-directory name without the leading `~`.
+
+The client MUST respond with one LF-terminated answer line for each query body line. The first answer resolves the first queried name, the second answer resolves the second queried name, and so on. A non-empty answer is the resolved absolute path, percent-encoded per <<encoding-values>>. An empty answer means the named directory was not found.
+
 [[cmd-hlo]]
 === Hello (`CMD=HLO`)
 
@@ -353,7 +360,7 @@ where `<version>` is the daemon's application version string (e.g., `1.7.0`).
 
 == Version Negotiation
 
-The client MUST include `VER=2` in every request. If the daemon receives an unsupported `VER` value, it MUST close the connection immediately without sending any response. The client MUST ignore empty responses.
+The client MUST include `VER=3` in every request. If the daemon receives an unsupported `VER` value, it MUST close the connection immediately without sending any response. The client MUST ignore empty responses.
 
 == Error Handling
 

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -27,7 +27,6 @@ use crate::{
         CallableType, DynamicStyle, Highlighter, HighlighterBuilder, HighlightingRequest, Span,
         SpanStyle, StaticStyle,
     },
-    path::potential_nameddirs,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -673,6 +672,7 @@ fn handle_connection_v1<R: BufRead, W: Write>(
                         ))
                     }
                 }
+                DynamicStyle::Nameddir { .. } => None,
             },
         };
 
@@ -1021,6 +1021,7 @@ where
         .with_cursor(pre_buffer_total_len + cursor)
         .with_pwd(pwd.as_deref())
         .with_autocd(autocd_enabled)
+        .with_nameddirs(supports_nameddirs)
         .with_history_expansions(history_expansions_enabled)
         .with_predicate(|range| {
             // skip spans in the pre-buffer
@@ -1035,17 +1036,53 @@ where
             // skip spans outside the current terminal window
             start < max && end > min
         });
-    let names = potential_nameddirs(&lines).collect::<FxHashSet<_>>();
-    let nameddirs = if supports_nameddirs && !names.is_empty() {
+    let mut result = highlighter.highlight(&lines, &request)?;
+
+    // collect unique nameddirs that need to be resolved
+    let nameddirs_to_resolve = result
+        .iter()
+        .filter_map(|span| match &span.style {
+            SpanStyle::Dynamic(DynamicStyle::Nameddir { name, .. }) => Some(name.as_str()),
+            _ => None,
+        })
+        .collect::<FxHashSet<_>>();
+    // resolve nameddirs to their absolute paths
+    let resolved_nameddirs = if supports_nameddirs && !nameddirs_to_resolve.is_empty() {
         resolve_nameddirs(
-            &names.into_iter().collect::<Vec<_>>(),
+            &nameddirs_to_resolve.into_iter().collect::<Vec<_>>(),
             &mut reader,
             &mut writer,
         )?
     } else {
         FxHashMap::default()
     };
-    let result = highlighter.highlight(&lines, &request.with_nameddirs(&nameddirs))?;
+
+    // re-classify Nameddir-style Spans with their intended final style
+    result.retain_mut(|span| {
+        let SpanStyle::Dynamic(DynamicStyle::Nameddir {
+            name,
+            parsed_path,
+            dynamic_type,
+        }) = &span.style
+        else {
+            return true;
+        };
+
+        let mut path = parsed_path.clone();
+        if let Some(directory) = resolved_nameddirs
+            .get(name)
+            .filter(|directory| !directory.is_empty())
+        {
+            path.replace_range(0..name.len() + 1, directory);
+        }
+        let Some(style) =
+            highlighter.classify_dynamic(path, &(span.start..span.end), *dynamic_type, &request)
+        else {
+            return false;
+        };
+        span.style = style;
+        true
+    });
 
     // merge consecutive spans with the same style
     let mut merged: Vec<Span> = Vec::new();
@@ -1107,6 +1144,7 @@ where
                         .filter(|s| !s.is_empty())
                         .map(|style| format!("{} {} {}\n", s.start, s.end, style))
                 }),
+            SpanStyle::Dynamic(DynamicStyle::Nameddir { .. }) => None,
         };
 
         if let Some(message) = message {

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1063,6 +1063,7 @@ where
             name,
             parsed_path,
             dynamic_type,
+            base_style,
         }) = &span.style
         else {
             return true;
@@ -1075,9 +1076,13 @@ where
         {
             path.replace_range(0..name.len() + 1, directory);
         }
-        let Some(style) =
-            highlighter.classify_dynamic(path, &(span.start..span.end), *dynamic_type, &request)
-        else {
+        let Some(style) = highlighter.classify_dynamic(
+            path,
+            &(span.start..span.end),
+            *dynamic_type,
+            base_style.as_ref(),
+            &request,
+        ) else {
             return false;
         };
         span.style = style;

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -27,6 +27,7 @@ use crate::{
         CallableType, DynamicStyle, Highlighter, HighlighterBuilder, HighlightingRequest, Span,
         SpanStyle, StaticStyle,
     },
+    path::potential_nameddirs,
 };
 
 #[derive(Clone, Copy, PartialEq, Eq)]
@@ -335,14 +336,15 @@ fn handle_connection(stream: UnixStream, highlighter: Arc<Highlighter>) -> Resul
 
     let version = first_line.strip_prefix("VER=").unwrap_or("1");
     match version {
-        "2" => handle_connection_v2(reader, writer, &highlighter),
+        "3" => handle_connection_v2(reader, writer, &highlighter, true),
+        "2" => handle_connection_v2(reader, writer, &highlighter, false),
         "1" => handle_connection_v1(reader, writer, first_line, highlighter),
         _ => {
             // Return immediately. This will close the connection with an empty
             // response.
             log::error!(
                 "Client protocol version is {version:?}. Expected protocol \
-                version is \"1\" or \"2\"."
+                version is \"1\", \"2\", or \"3\"."
             );
             Ok(())
         }
@@ -723,6 +725,7 @@ fn handle_connection_v2<R: BufRead, W: Write>(
     mut reader: R,
     writer: W,
     highlighter: &Highlighter,
+    supports_nameddirs: bool,
 ) -> Result<()> {
     let mut cmd = Command::Highlight;
     let mut body_line_count = 0;
@@ -771,9 +774,14 @@ fn handle_connection_v2<R: BufRead, W: Write>(
 
     match cmd {
         Command::Hello => handle_hello(writer),
-        Command::Highlight => {
-            handle_highlight(header_lines, body_lines, reader, writer, highlighter)
-        }
+        Command::Highlight => handle_highlight(
+            header_lines,
+            body_lines,
+            reader,
+            writer,
+            highlighter,
+            supports_nameddirs,
+        ),
     }
 }
 
@@ -795,6 +803,7 @@ fn handle_highlight<R, W>(
     mut reader: R,
     mut writer: W,
     highlighter: &Highlighter,
+    supports_nameddirs: bool,
 ) -> Result<()>
 where
     R: BufRead,
@@ -1026,7 +1035,17 @@ where
             // skip spans outside the current terminal window
             start < max && end > min
         });
-    let result = highlighter.highlight(&lines, &request)?;
+    let names = potential_nameddirs(&lines).collect::<FxHashSet<_>>();
+    let nameddirs = if supports_nameddirs && !names.is_empty() {
+        resolve_nameddirs(
+            &names.into_iter().collect::<Vec<_>>(),
+            &mut reader,
+            &mut writer,
+        )?
+    } else {
+        FxHashMap::default()
+    };
+    let result = highlighter.highlight(&lines, &request.with_nameddirs(&nameddirs))?;
 
     // merge consecutive spans with the same style
     let mut merged: Vec<Span> = Vec::new();
@@ -1133,6 +1152,35 @@ where
     )?;
 
     Ok(())
+}
+
+fn resolve_nameddirs<R, W>(
+    names: &[&str],
+    reader: &mut R,
+    writer: &mut W,
+) -> Result<FxHashMap<String, String>>
+where
+    R: BufRead,
+    W: Write,
+{
+    writer
+        .write_all(format!("?CMD=NMD\nLNS={}\n\n", names.len()).as_bytes())
+        .context("Unable to send NMD query")?;
+    for name in names {
+        writeln!(writer, "{}", encode_string(name)).context("Unable to send NMD query body")?;
+    }
+    writer.flush().context("Unable to flush NMD query")?;
+
+    let mut result = FxHashMap::default();
+    for name in names {
+        let mut answer = String::new();
+        reader
+            .read_line(&mut answer)
+            .context("Unable to read NMD answer")?;
+        let answer = decode_string(answer.trim_ascii_end());
+        result.insert((*name).to_owned(), answer);
+    }
+    Ok(result)
 }
 
 /// Resolve a list of callables to their CallableTypes by asking the client. If
@@ -1259,7 +1307,7 @@ pub fn activate(runtime_dir: &Path, config: &Config) -> Result<()> {
                 .unwrap()
                 .trim_end_matches('/')
                 .to_string(),
-            version: "2",
+            version: "3",
         };
 
         let mut s = stdout().lock();
@@ -1277,7 +1325,7 @@ pub fn activate(runtime_dir: &Path, config: &Config) -> Result<()> {
         stream.set_read_timeout(Some(timeout))?;
         stream.set_write_timeout(Some(timeout))?;
 
-        stream.write_all(b"VER=2\nCMD=HLO\n\n")?;
+        stream.write_all(b"VER=3\nCMD=HLO\n\n")?;
 
         let mut response = String::new();
         let mut reader = BufReader::new(&stream);

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1197,6 +1197,7 @@ where
     Ok(())
 }
 
+/// Resolve named directories to absolute paths by asking the client.
 fn resolve_nameddirs<R, W>(
     names: &[&str],
     reader: &mut R,

--- a/src/highlighting/dynamic.rs
+++ b/src/highlighting/dynamic.rs
@@ -109,6 +109,7 @@ impl DynamicTokenGroup {
                     name,
                     parsed_path: p,
                     dynamic_type: DynamicType::Callable,
+                    base_style: None,
                 }))
             } else {
                 classify_callable(p, &range, options)
@@ -142,6 +143,7 @@ impl DynamicTokenGroup {
                     name,
                     parsed_path: p,
                     dynamic_type: DynamicType::Arguments,
+                    base_style: None,
                 }))
             } else {
                 classify_argument(&p, &range, options)

--- a/src/highlighting/dynamic.rs
+++ b/src/highlighting/dynamic.rs
@@ -52,6 +52,8 @@ pub struct DynamicHighlightingOptions<'a> {
     home_dir: &'a str,
     theme: &'a Theme,
     highlight_partial_paths: bool,
+    // TODO: this should always be true starting from protocol v3, stop passing
+    // it around once v1 and v2 are decommissioned.
     resolve_nameddirs: bool,
 }
 
@@ -194,14 +196,17 @@ impl DynamicTokenGroup {
 
             fn push_string(&mut self) -> Result<()> {
                 if !self.s.is_empty() && !self.is_poison {
-                    // resolve tilde only if the whole string is a tilde or if it starts
-                    // with '~/', because '~foobar', for example, should not be resolved
                     let nameddir = if !self.resolve_tilde {
                         None
                     } else if self.s == "~" || self.s.starts_with("~/") {
+                        // statically resolve a leading tilde as standalone path
+                        // segment to the user's home directory
                         self.s.replace_range(0..1, self.home_dir);
                         None
                     } else {
+                        // other occurrences of leading tildes, such as in
+                        // '~foobar', presumably refer to named directories and
+                        // require dynamic resolution
                         named_directory(&self.s).map(str::to_owned)
                     };
                     self.result
@@ -384,6 +389,8 @@ pub(super) fn classify_callable(
             .or_else(|| resolve_static_style(CALLABLE, options.theme))
             .map(SpanStyle::Static)
     } else if options.autocd {
+        // only perform highlighting of partial paths if it is enabled and if
+        // the cursor touches the prefix
         let partial = options.highlight_partial_paths
             && options
                 .cursor
@@ -412,6 +419,8 @@ pub(super) fn classify_argument(
     range: &Range<usize>,
     options: &DynamicHighlightingOptions,
 ) -> Option<SpanStyle> {
+    // only perform highlighting of partial paths if it is enabled and if the
+    // cursor touches the prefix
     let partial = options.highlight_partial_paths
         && options
             .cursor

--- a/src/highlighting/dynamic.rs
+++ b/src/highlighting/dynamic.rs
@@ -50,9 +50,9 @@ pub struct DynamicHighlightingOptions<'a> {
     pwd: &'a str,
     autocd: bool,
     home_dir: &'a str,
-    nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
     theme: &'a Theme,
     highlight_partial_paths: bool,
+    resolve_nameddirs: bool,
 }
 
 impl<'a> DynamicHighlightingOptions<'a> {
@@ -61,18 +61,18 @@ impl<'a> DynamicHighlightingOptions<'a> {
         pwd: &'a str,
         autocd: bool,
         home_dir: &'a str,
-        nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
         theme: &'a Theme,
         highlight_partial_paths: bool,
+        resolve_nameddirs: bool,
     ) -> Self {
         Self {
             cursor,
             pwd,
             autocd,
             home_dir,
-            nameddirs,
             theme,
             highlight_partial_paths,
+            resolve_nameddirs,
         }
     }
 }
@@ -99,43 +99,20 @@ impl DynamicTokenGroup {
     ) -> Result<Vec<Span>> {
         let mut result = Vec::new();
 
-        let parsed = self.parse(line, options)?;
-        for (p, range) in parsed.into_iter().take(1) {
+        let parsed = self.parse(line, options.home_dir)?;
+        for (p, range, nameddir) in parsed.into_iter().take(1) {
             log::trace!("Dynamically highlighting callable: {p}");
-            let span_style = if p == "."
-                || p == ".."
-                || (p.contains('/') && is_path_executable(&p, options.pwd, options.autocd))
+            let span_style = if options.resolve_nameddirs
+                && let Some(name) = nameddir
             {
-                log::trace!("Callable `{p}' is executable.");
-                resolve_static_style(DYNAMIC_CALLABLE_COMMAND, options.theme)
-                    .or_else(|| resolve_static_style(CALLABLE, options.theme))
-                    .map(SpanStyle::Static)
-            } else if options.autocd {
-                // only perform highlighting of partial paths if it is enabled and
-                // if the cursor touches the prefix
-                let partial = options.highlight_partial_paths
-                    && options
-                        .cursor
-                        .map(|c| (range.start..=range.end).contains(&c))
-                        .unwrap_or_default();
-
-                match path_type(&p, options.pwd, partial) {
-                    Some((PathType::Directory, _)) => {
-                        log::trace!("Callable `{p}' is a directory (autocd).");
-                        resolve_static_style(DYNAMIC_CALLABLE_COMMAND, options.theme)
-                            .or_else(|| resolve_static_style(CALLABLE, options.theme))
-                            .map(SpanStyle::Static)
-                    }
-                    _ => Some(SpanStyle::Dynamic(DynamicStyle::Callable {
-                        parsed_callable: p,
-                    })),
-                }
-            } else {
-                Some(SpanStyle::Dynamic(DynamicStyle::Callable {
-                    parsed_callable: p,
+                Some(SpanStyle::Dynamic(DynamicStyle::Nameddir {
+                    name,
+                    parsed_path: p,
+                    dynamic_type: DynamicType::Callable,
                 }))
+            } else {
+                classify_callable(p, &range, options)
             };
-
             if let Some(span_style) = span_style {
                 result.push(Span {
                     start: range.start,
@@ -155,33 +132,26 @@ impl DynamicTokenGroup {
     ) -> Result<Vec<Span>> {
         let mut result = Vec::new();
 
-        let parsed = self.parse(line, options)?;
-        for (p, range) in parsed {
+        let parsed = self.parse(line, options.home_dir)?;
+        for (p, range, nameddir) in parsed {
             log::trace!("Dynamically highlighting argument: {p}");
-
-            // only perform highlighting of partial paths if it is enabled and
-            // if the cursor touches the prefix
-            let partial = options.highlight_partial_paths
-                && options
-                    .cursor
-                    .map(|c| (range.start..=range.end).contains(&c))
-                    .unwrap_or_default();
-
-            if let Some((t, matched_partially)) = path_type(&p, options.pwd, partial) {
-                log::trace!("Argument `{p}' is {t:?}.");
-                let dynamic_scope = match (t, matched_partially) {
-                    (PathType::File, true) => DYNAMIC_PATH_FILE_PARTIAL,
-                    (PathType::File, false) => DYNAMIC_PATH_FILE_COMPLETE,
-                    (PathType::Directory, true) => DYNAMIC_PATH_DIRECTORY_PARTIAL,
-                    (PathType::Directory, false) => DYNAMIC_PATH_DIRECTORY_COMPLETE,
-                };
-                if let Some(style) = resolve_static_style(dynamic_scope, options.theme) {
-                    result.push(Span {
-                        start: range.start,
-                        end: range.end,
-                        style: SpanStyle::Static(style),
-                    });
-                }
+            let style = if options.resolve_nameddirs
+                && let Some(name) = nameddir
+            {
+                Some(SpanStyle::Dynamic(DynamicStyle::Nameddir {
+                    name,
+                    parsed_path: p,
+                    dynamic_type: DynamicType::Arguments,
+                }))
+            } else {
+                classify_argument(&p, &range, options)
+            };
+            if let Some(style) = style {
+                result.push(Span {
+                    start: range.start,
+                    end: range.end,
+                    style,
+                });
             }
         }
 
@@ -191,22 +161,21 @@ impl DynamicTokenGroup {
     fn parse(
         &self,
         line: &str,
-        options: &DynamicHighlightingOptions,
-    ) -> Result<Vec<(String, Range<usize>)>> {
+        home_dir: &str,
+    ) -> Result<Vec<(String, Range<usize>, Option<String>)>> {
         if self.tokens.is_empty() {
             return Ok(Vec::new());
         }
 
         struct State<'a> {
             home_dir: &'a str,
-            nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
             s: String,
             start: usize,
             end: usize,
             utf8_buf: Vec<u8>,
             resolve_tilde: bool,
             is_poison: bool,
-            result: Vec<(String, Range<usize>)>,
+            result: Vec<(String, Range<usize>, Option<String>)>,
         }
 
         impl State<'_> {
@@ -223,25 +192,18 @@ impl DynamicTokenGroup {
 
             fn push_string(&mut self) -> Result<()> {
                 if !self.s.is_empty() && !self.is_poison {
-                    // Resolve bare tilde locally and named directories supplied
-                    // by the Zsh client in response to NMD requests.
-                    if self.resolve_tilde {
-                        if self.s == "~" || self.s.starts_with("~/") {
-                            self.s.replace_range(0..1, self.home_dir);
-                        } else if let Some((name, home)) =
-                            named_directory(&self.s).and_then(|name| {
-                                self.nameddirs?
-                                    .get(name)
-                                    .filter(|home| !home.is_empty())
-                                    .map(|home| (name, home))
-                            })
-                        {
-                            self.s.replace_range(0..name.len() + 1, home);
-                        }
-                    }
-
+                    // resolve tilde only if the whole string is a tilde or if it starts
+                    // with '~/', because '~foobar', for example, should not be resolved
+                    let nameddir = if !self.resolve_tilde {
+                        None
+                    } else if self.s == "~" || self.s.starts_with("~/") {
+                        self.s.replace_range(0..1, self.home_dir);
+                        None
+                    } else {
+                        named_directory(&self.s).map(str::to_owned)
+                    };
                     self.result
-                        .push((std::mem::take(&mut self.s), self.start..self.end));
+                        .push((std::mem::take(&mut self.s), self.start..self.end, nameddir));
                 } else {
                     self.s = String::new();
                 }
@@ -255,8 +217,7 @@ impl DynamicTokenGroup {
 
         let chars_count = line[0..self.tokens[0].byte_range.start].chars().count();
         let mut state = State {
-            home_dir: options.home_dir,
-            nameddirs: options.nameddirs,
+            home_dir,
             s: String::new(),
             start: chars_count,
             end: chars_count,
@@ -405,6 +366,65 @@ impl DynamicTokenGroup {
 
         Ok(state.result)
     }
+}
+
+pub(super) fn classify_callable(
+    path: String,
+    range: &Range<usize>,
+    options: &DynamicHighlightingOptions,
+) -> Option<SpanStyle> {
+    if path == "."
+        || path == ".."
+        || (path.contains('/') && is_path_executable(&path, options.pwd, options.autocd))
+    {
+        log::trace!("Callable `{path}' is executable.");
+        resolve_static_style(DYNAMIC_CALLABLE_COMMAND, options.theme)
+            .or_else(|| resolve_static_style(CALLABLE, options.theme))
+            .map(SpanStyle::Static)
+    } else if options.autocd {
+        let partial = options.highlight_partial_paths
+            && options
+                .cursor
+                .map(|cursor| (range.start..=range.end).contains(&cursor))
+                .unwrap_or_default();
+        match path_type(&path, options.pwd, partial) {
+            Some((PathType::Directory, _)) => {
+                log::trace!("Callable `{path}' is a directory (autocd).");
+                resolve_static_style(DYNAMIC_CALLABLE_COMMAND, options.theme)
+                    .or_else(|| resolve_static_style(CALLABLE, options.theme))
+                    .map(SpanStyle::Static)
+            }
+            _ => Some(SpanStyle::Dynamic(DynamicStyle::Callable {
+                parsed_callable: path,
+            })),
+        }
+    } else {
+        Some(SpanStyle::Dynamic(DynamicStyle::Callable {
+            parsed_callable: path,
+        }))
+    }
+}
+
+pub(super) fn classify_argument(
+    path: &str,
+    range: &Range<usize>,
+    options: &DynamicHighlightingOptions,
+) -> Option<SpanStyle> {
+    let partial = options.highlight_partial_paths
+        && options
+            .cursor
+            .map(|cursor| (range.start..=range.end).contains(&cursor))
+            .unwrap_or_default();
+    let (path_type, matched_partially) = path_type(path, options.pwd, partial)?;
+
+    log::trace!("Argument `{path}' is {path_type:?}.");
+    let dynamic_scope = match (path_type, matched_partially) {
+        (PathType::File, true) => DYNAMIC_PATH_FILE_PARTIAL,
+        (PathType::File, false) => DYNAMIC_PATH_FILE_COMPLETE,
+        (PathType::Directory, true) => DYNAMIC_PATH_DIRECTORY_PARTIAL,
+        (PathType::Directory, false) => DYNAMIC_PATH_DIRECTORY_COMPLETE,
+    };
+    resolve_static_style(dynamic_scope, options.theme).map(SpanStyle::Static)
 }
 
 #[derive(Clone, Copy)]

--- a/src/highlighting/dynamic.rs
+++ b/src/highlighting/dynamic.rs
@@ -4,7 +4,7 @@ use anyhow::{Context, Result};
 use syntect::parsing::{ClearAmount, Scope, ScopeStackOp};
 
 use crate::{
-    path::{PathType, is_path_executable, path_type},
+    path::{PathType, is_path_executable, named_directory, path_type},
     unescape::ZshUnescape,
 };
 
@@ -50,6 +50,7 @@ pub struct DynamicHighlightingOptions<'a> {
     pwd: &'a str,
     autocd: bool,
     home_dir: &'a str,
+    nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
     theme: &'a Theme,
     highlight_partial_paths: bool,
 }
@@ -60,6 +61,7 @@ impl<'a> DynamicHighlightingOptions<'a> {
         pwd: &'a str,
         autocd: bool,
         home_dir: &'a str,
+        nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
         theme: &'a Theme,
         highlight_partial_paths: bool,
     ) -> Self {
@@ -68,6 +70,7 @@ impl<'a> DynamicHighlightingOptions<'a> {
             pwd,
             autocd,
             home_dir,
+            nameddirs,
             theme,
             highlight_partial_paths,
         }
@@ -96,7 +99,7 @@ impl DynamicTokenGroup {
     ) -> Result<Vec<Span>> {
         let mut result = Vec::new();
 
-        let parsed = self.parse(line, options.home_dir)?;
+        let parsed = self.parse(line, options)?;
         for (p, range) in parsed.into_iter().take(1) {
             log::trace!("Dynamically highlighting callable: {p}");
             let span_style = if p == "."
@@ -152,7 +155,7 @@ impl DynamicTokenGroup {
     ) -> Result<Vec<Span>> {
         let mut result = Vec::new();
 
-        let parsed = self.parse(line, options.home_dir)?;
+        let parsed = self.parse(line, options)?;
         for (p, range) in parsed {
             log::trace!("Dynamically highlighting argument: {p}");
 
@@ -185,13 +188,18 @@ impl DynamicTokenGroup {
         Ok(result)
     }
 
-    fn parse(&self, line: &str, home_dir: &str) -> Result<Vec<(String, Range<usize>)>> {
+    fn parse(
+        &self,
+        line: &str,
+        options: &DynamicHighlightingOptions,
+    ) -> Result<Vec<(String, Range<usize>)>> {
         if self.tokens.is_empty() {
             return Ok(Vec::new());
         }
 
         struct State<'a> {
             home_dir: &'a str,
+            nameddirs: Option<&'a rustc_hash::FxHashMap<String, String>>,
             s: String,
             start: usize,
             end: usize,
@@ -215,10 +223,21 @@ impl DynamicTokenGroup {
 
             fn push_string(&mut self) -> Result<()> {
                 if !self.s.is_empty() && !self.is_poison {
-                    // resolve tilde only if the whole string is a tilde or if it starts
-                    // with '~/', because '~foobar', for example, should not be resolved
-                    if self.resolve_tilde && (self.s == "~" || self.s.starts_with("~/")) {
-                        self.s.replace_range(0..1, self.home_dir);
+                    // Resolve bare tilde locally and named directories supplied
+                    // by the Zsh client in response to NMD requests.
+                    if self.resolve_tilde {
+                        if self.s == "~" || self.s.starts_with("~/") {
+                            self.s.replace_range(0..1, self.home_dir);
+                        } else if let Some((name, home)) =
+                            named_directory(&self.s).and_then(|name| {
+                                self.nameddirs?
+                                    .get(name)
+                                    .filter(|home| !home.is_empty())
+                                    .map(|home| (name, home))
+                            })
+                        {
+                            self.s.replace_range(0..name.len() + 1, home);
+                        }
                     }
 
                     self.result
@@ -236,7 +255,8 @@ impl DynamicTokenGroup {
 
         let chars_count = line[0..self.tokens[0].byte_range.start].chars().count();
         let mut state = State {
-            home_dir,
+            home_dir: options.home_dir,
+            nameddirs: options.nameddirs,
             s: String::new(),
             start: chars_count,
             end: chars_count,

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -195,7 +195,6 @@ where
     pub fn with_pwd<'b, O>(&self, pwd: O) -> HighlightingRequest<'b, P>
     where
         O: Into<Option<&'b str>>,
-        'a: 'b,
     {
         HighlightingRequest {
             pwd: pwd.into(),
@@ -221,7 +220,8 @@ where
         }
     }
 
-    pub(crate) fn with_nameddirs(&self, enabled: bool) -> Self {
+    /// Enable or disable support for named directories resolution
+    pub fn with_nameddirs(&self, enabled: bool) -> Self {
         Self {
             resolve_nameddirs: enabled,
             ..*self
@@ -352,6 +352,8 @@ impl Highlighter {
         &self.callable_choices
     }
 
+    /// Classify a resolved dynamic path and combine the resulting style with
+    /// the static style captured before named-directory resolution.
     pub fn classify_dynamic<P>(
         &self,
         path: String,
@@ -698,11 +700,11 @@ pub mod tests {
                         }
                     }
                     SpanStyle::Dynamic(dynamic_style) => match dynamic_style {
-                        DynamicStyle::Nameddir { parsed_path, .. } => {
-                            write!(tw, "NAMEDDIR `{parsed_path}`").unwrap();
-                        }
                         DynamicStyle::Callable { parsed_callable } => {
                             write!(tw, "CALLABLE `{parsed_callable}`").unwrap();
+                        }
+                        DynamicStyle::Nameddir { parsed_path, .. } => {
+                            write!(tw, "NAMEDDIR `{parsed_path}`").unwrap();
                         }
                     },
                 }

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -102,6 +102,21 @@ fn mix_styles(base: &SpanStyle, mixin: &SpanStyle) -> SpanStyle {
             underline: if m.underline { true } else { b.underline },
         }),
 
+        (
+            SpanStyle::Static(base_style),
+            SpanStyle::Dynamic(DynamicStyle::Nameddir {
+                name,
+                parsed_path,
+                dynamic_type,
+                ..
+            }),
+        ) => SpanStyle::Dynamic(DynamicStyle::Nameddir {
+            name: name.clone(),
+            parsed_path: parsed_path.clone(),
+            dynamic_type: *dynamic_type,
+            base_style: Some(base_style.clone()),
+        }),
+
         (_, SpanStyle::Dynamic(m)) => SpanStyle::Dynamic(m.clone()),
 
         // this should actually be unreachable since base should always only
@@ -342,6 +357,7 @@ impl Highlighter {
         path: String,
         range: &Range<usize>,
         dynamic_type: DynamicType,
+        base_style: Option<&StaticStyle>,
         request: &HighlightingRequest<P>,
     ) -> Option<SpanStyle>
     where
@@ -356,10 +372,17 @@ impl Highlighter {
             self.dynamic_arguments_type == DynamicConfigType::Partial,
             request.resolve_nameddirs,
         );
-        match dynamic_type {
+        let style = match dynamic_type {
             DynamicType::Callable => classify_callable(path, range, &options),
             DynamicType::Arguments => classify_argument(&path, range, &options),
             DynamicType::Unknown => None,
+        };
+        match (base_style, style) {
+            (Some(base_style), Some(style)) => {
+                Some(mix_styles(&SpanStyle::Static(base_style.clone()), &style))
+            }
+            (Some(base_style), None) => Some(SpanStyle::Static(base_style.clone())),
+            (None, style) => style,
         }
     }
 

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -19,6 +19,7 @@ use crate::{
     highlighting::{
         dynamic::{
             DynamicHighlightingOptions, DynamicScopes, DynamicTokenGroupBuilder, DynamicType,
+            classify_argument, classify_callable,
         },
         historyexpansion::HistoryExpanded,
         syntax::load_syntax_set,
@@ -159,7 +160,7 @@ where
     pwd: Option<&'a str>,
     history_expansions_enabled: bool,
     autocd_enabled: bool,
-    nameddirs: Option<&'a FxHashMap<String, String>>,
+    resolve_nameddirs: bool,
     predicate: P,
 }
 
@@ -205,6 +206,13 @@ where
         }
     }
 
+    pub(crate) fn with_nameddirs(&self, enabled: bool) -> Self {
+        Self {
+            resolve_nameddirs: enabled,
+            ..*self
+        }
+    }
+
     /// Set the predicate function that determines which spans should be
     /// highlighted The predicate function takes a character index range and
     /// returns `true` if the span within that range should be highlighted, and
@@ -218,21 +226,8 @@ where
             pwd: self.pwd,
             history_expansions_enabled: self.history_expansions_enabled,
             autocd_enabled: self.autocd_enabled,
-            nameddirs: self.nameddirs,
+            resolve_nameddirs: self.resolve_nameddirs,
             predicate,
-        }
-    }
-
-    pub(crate) fn with_nameddirs<'b>(
-        &self,
-        nameddirs: &'b FxHashMap<String, String>,
-    ) -> HighlightingRequest<'b, P>
-    where
-        'a: 'b,
-    {
-        HighlightingRequest {
-            nameddirs: Some(nameddirs),
-            ..*self
         }
     }
 }
@@ -244,7 +239,7 @@ impl Default for HighlightingRequest<'_, fn(&Range<usize>) -> bool> {
             pwd: None,
             history_expansions_enabled: true,
             autocd_enabled: false,
-            nameddirs: None,
+            resolve_nameddirs: false,
             predicate: |_: &Range<usize>| true,
         }
     }
@@ -342,6 +337,32 @@ impl Highlighter {
         &self.callable_choices
     }
 
+    pub fn classify_dynamic<P>(
+        &self,
+        path: String,
+        range: &Range<usize>,
+        dynamic_type: DynamicType,
+        request: &HighlightingRequest<P>,
+    ) -> Option<SpanStyle>
+    where
+        P: Fn(&Range<usize>) -> bool + Copy,
+    {
+        let options = DynamicHighlightingOptions::new(
+            request.cursor,
+            request.pwd?,
+            request.autocd_enabled,
+            &self.home_dir,
+            &self.theme,
+            self.dynamic_arguments_type == DynamicConfigType::Partial,
+            request.resolve_nameddirs,
+        );
+        match dynamic_type {
+            DynamicType::Callable => classify_callable(path, range, &options),
+            DynamicType::Arguments => classify_argument(&path, range, &options),
+            DynamicType::Unknown => None,
+        }
+    }
+
     fn should_highlight_dynamic(&self, dynamic_type: &DynamicType) -> bool {
         match dynamic_type {
             DynamicType::Unknown => true,
@@ -371,9 +392,9 @@ impl Highlighter {
                 pwd,
                 request.autocd_enabled,
                 &self.home_dir,
-                request.nameddirs,
                 &self.theme,
                 self.dynamic_arguments_type == DynamicConfigType::Partial,
+                request.resolve_nameddirs,
             )
         });
 
@@ -654,6 +675,9 @@ pub mod tests {
                         }
                     }
                     SpanStyle::Dynamic(dynamic_style) => match dynamic_style {
+                        DynamicStyle::Nameddir { parsed_path, .. } => {
+                            write!(tw, "NAMEDDIR `{parsed_path}`").unwrap();
+                        }
                         DynamicStyle::Callable { parsed_callable } => {
                             write!(tw, "CALLABLE `{parsed_callable}`").unwrap();
                         }

--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -159,6 +159,7 @@ where
     pwd: Option<&'a str>,
     history_expansions_enabled: bool,
     autocd_enabled: bool,
+    nameddirs: Option<&'a FxHashMap<String, String>>,
     predicate: P,
 }
 
@@ -178,6 +179,7 @@ where
     pub fn with_pwd<'b, O>(&self, pwd: O) -> HighlightingRequest<'b, P>
     where
         O: Into<Option<&'b str>>,
+        'a: 'b,
     {
         HighlightingRequest {
             pwd: pwd.into(),
@@ -216,7 +218,21 @@ where
             pwd: self.pwd,
             history_expansions_enabled: self.history_expansions_enabled,
             autocd_enabled: self.autocd_enabled,
+            nameddirs: self.nameddirs,
             predicate,
+        }
+    }
+
+    pub(crate) fn with_nameddirs<'b>(
+        &self,
+        nameddirs: &'b FxHashMap<String, String>,
+    ) -> HighlightingRequest<'b, P>
+    where
+        'a: 'b,
+    {
+        HighlightingRequest {
+            nameddirs: Some(nameddirs),
+            ..*self
         }
     }
 }
@@ -228,6 +244,7 @@ impl Default for HighlightingRequest<'_, fn(&Range<usize>) -> bool> {
             pwd: None,
             history_expansions_enabled: true,
             autocd_enabled: false,
+            nameddirs: None,
             predicate: |_: &Range<usize>| true,
         }
     }
@@ -354,6 +371,7 @@ impl Highlighter {
                 pwd,
                 request.autocd_enabled,
                 &self.home_dir,
+                request.nameddirs,
                 &self.theme,
                 self.dynamic_arguments_type == DynamicConfigType::Partial,
             )

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -7,7 +7,7 @@ mod syntax;
 
 pub use highlighter::{CallableType, Highlighter, HighlighterBuilder, HighlightingRequest};
 
-use crate::theme::Theme;
+use crate::{highlighting::dynamic::DynamicType, theme::Theme};
 
 const ARGUMENTS: &str = "meta.function-call.arguments.shell";
 const DYNAMIC_PATH_DIRECTORY_COMPLETE: &str = "dynamic.path.directory.complete.shell";
@@ -69,7 +69,14 @@ pub struct StaticStyle {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DynamicStyle {
-    Callable { parsed_callable: String },
+    Callable {
+        parsed_callable: String,
+    },
+    Nameddir {
+        name: String,
+        parsed_path: String,
+        dynamic_type: DynamicType,
+    },
 }
 
 #[derive(Clone, PartialEq, Eq, Debug)]

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -76,6 +76,7 @@ pub enum DynamicStyle {
         name: String,
         parsed_path: String,
         dynamic_type: DynamicType,
+        base_style: Option<StaticStyle>,
     },
 }
 

--- a/src/highlighting/mod.rs
+++ b/src/highlighting/mod.rs
@@ -69,13 +69,20 @@ pub struct StaticStyle {
 
 #[derive(Clone, PartialEq, Eq, Debug)]
 pub enum DynamicStyle {
+    /// A callable whose type must be resolved by the client
     Callable {
+        /// The parsed callable name
         parsed_callable: String,
     },
+    /// A path containing a named directory that must be resolved by the client
     Nameddir {
+        /// The named-directory name, without the leading tilde
         name: String,
+        /// The complete parsed path containing the named directory
         parsed_path: String,
+        /// Whether the path belongs to a callable or an argument expression
         dynamic_type: DynamicType,
+        /// The static grammar style to combine with the resolved path style
         base_style: Option<StaticStyle>,
     },
 }

--- a/src/path.rs
+++ b/src/path.rs
@@ -20,20 +20,6 @@ pub fn named_directory(path: &str) -> Option<&str> {
     .then_some(name)
 }
 
-/// Find potential named-directory expressions in a command line.  These
-/// may be false positive, merely used to query the client for preliminary
-/// named-directory mappings.
-pub fn potential_nameddirs(command: &str) -> impl Iterator<Item = &str> {
-    command.match_indices('~').filter_map(|(start, _)| {
-        let rest = &command[start..];
-        let end = rest[1..]
-            .find(|c: char| !(c.is_alphanumeric() || matches!(c, '_' | '-' | '.')))
-            .map(|i| i + 1)
-            .unwrap_or(rest.len());
-        named_directory(&rest[..end])
-    })
-}
-
 /// Find a file or directory that starts with the given prefix and return its
 /// metadata.
 /// * If the prefix is relative, it is resolved against the provided `pwd`.
@@ -152,7 +138,7 @@ mod tests {
     use std::os::unix::fs::PermissionsExt;
 
     #[test]
-    fn parse_potential_nameddirs() {
+    fn parse_nameddirs() {
         assert_eq!(
             named_directory("~some_dir-1.0/testfile"),
             Some("some_dir-1.0")
@@ -160,10 +146,6 @@ mod tests {
         assert_eq!(named_directory("~some+dir/testfile"), None);
         assert_eq!(named_directory("~/testfile"), None);
         assert_eq!(named_directory("hel~lo"), None);
-        assert_eq!(
-            potential_nameddirs("cp ~one/a '~two/b' x~three ~four+five").collect::<Vec<_>>(),
-            ["one", "two", "three", "four"]
-        );
     }
 
     #[test]

--- a/src/path.rs
+++ b/src/path.rs
@@ -10,6 +10,30 @@ pub enum PathType {
     Directory,
 }
 
+/// Return the name from a Zsh named-directory expression such as `~name/path`.
+pub fn named_directory(path: &str) -> Option<&str> {
+    let name = path.strip_prefix('~')?.split('/').next()?;
+    (!name.is_empty()
+        && name
+            .chars()
+            .all(|c| c.is_alphanumeric() || matches!(c, '_' | '-' | '.')))
+    .then_some(name)
+}
+
+/// Find potential named-directory expressions in a command line.  These
+/// may be false positive, merely used to query the client for preliminary
+/// named-directory mappings.
+pub fn potential_nameddirs(command: &str) -> impl Iterator<Item = &str> {
+    command.match_indices('~').filter_map(|(start, _)| {
+        let rest = &command[start..];
+        let end = rest[1..]
+            .find(|c: char| !(c.is_alphanumeric() || matches!(c, '_' | '-' | '.')))
+            .map(|i| i + 1)
+            .unwrap_or(rest.len());
+        named_directory(&rest[..end])
+    })
+}
+
 /// Find a file or directory that starts with the given prefix and return its
 /// metadata.
 /// * If the prefix is relative, it is resolved against the provided `pwd`.
@@ -126,6 +150,21 @@ mod tests {
 
     use std::fs::{self, Permissions};
     use std::os::unix::fs::PermissionsExt;
+
+    #[test]
+    fn parse_potential_nameddirs() {
+        assert_eq!(
+            named_directory("~some_dir-1.0/testfile"),
+            Some("some_dir-1.0")
+        );
+        assert_eq!(named_directory("~some+dir/testfile"), None);
+        assert_eq!(named_directory("~/testfile"), None);
+        assert_eq!(named_directory("hel~lo"), None);
+        assert_eq!(
+            potential_nameddirs("cp ~one/a '~two/b' x~three ~four+five").collect::<Vec<_>>(),
+            ["one", "two", "three", "four"]
+        );
+    }
 
     #[test]
     fn metadata_absolute_path() {

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -40,6 +40,13 @@ _zsh_patina_resolve_callable() {
     fi
 }
 
+_zsh_patina_resolve_nameddir() {
+    REPLY=
+    if [[ -n "$1" && "$1" != *[^[:alnum:]_.-]* ]]; then
+        eval "print -v REPLY -r -- ~${1}" 2>/dev/null
+    fi
+}
+
 _zsh_patina_encode_string() {
     # fast path
     [[ $1 != *[%$'\n']* ]] && { REPLY="$1"; return }
@@ -205,6 +212,14 @@ _zsh_patina() {
                         IFS= read -r -u "$fd" qline
                         _zsh_patina_decode_string "$qline"
                         _zsh_patina_resolve_callable "$REPLY" "$query_las"
+                        print -r -u "$fd" -- "$REPLY"
+                    done
+                elif [[ "$query_cmd" == "NMD" ]]; then
+                    for (( qi = 0; qi < query_lns; qi++ )); do
+                        IFS= read -r -u "$fd" qline
+                        _zsh_patina_decode_string "$qline"
+                        _zsh_patina_resolve_nameddir "$REPLY"
+                        _zsh_patina_encode_string "$REPLY"
                         print -r -u "$fd" -- "$REPLY"
                     done
                 else

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -22,9 +22,13 @@ use tokio::fs;
 const DYNAMIC_CALLABLE_ALIAS: &str = "dynamic.callable.alias.shell";
 const DYNAMIC_CALLABLE_COMMAND: &str = "dynamic.callable.command.shell";
 const DYNAMIC_CALLABLE_MISSING: &str = "dynamic.callable.missing.shell";
+const DYNAMIC_PATH_FILE_COMPLETE: &str = "dynamic.path.file.complete.shell";
+const ARGUMENTS: &str = "meta.function-call.arguments.shell";
 const OPERATOR_LOGICAL_AND: &str = "keyword.operator.logical.and.shell";
 const PUNCTUATION_PARAMETER: &str = "punctuation.definition.parameter.shell";
 const PARAMETER: &str = "variable.parameter.option.shell";
+const FUNCTION: &str = "variable.function.shell";
+const TILDE: &str = "variable.language.tilde.shell";
 
 static TEST_THEME: LazyLock<toml::Table> = LazyLock::new(|| {
     include_str!(concat!(env!("OUT_DIR"), "/test_theme.toml"))
@@ -32,24 +36,27 @@ static TEST_THEME: LazyLock<toml::Table> = LazyLock::new(|| {
         .expect("test_theme.toml must be valid TOML")
 });
 
-/// Look up a scope name in the test theme and return a region_highlight entry
-/// string for the given start/end positions. Foreground-only scopes produce
-/// `"<start> <end> fg=<n>"`, background-only scopes produce
-/// `"<start> <end> bg=<n>"`.
-fn h(start: usize, end: usize, scope: &str) -> String {
-    let value = TEST_THEME
-        .get(scope)
-        .unwrap_or_else(|| panic!("scope '{scope}' not found in test_theme.toml"));
-    match value {
-        toml::Value::Integer(n) => format!("{start} {end} fg={n}"),
-        toml::Value::Table(t) => {
-            let bg = t["background"]
-                .as_integer()
-                .expect("background must be an integer");
-            format!("{start} {end} bg={bg}")
-        }
-        _ => panic!("unexpected TOML value type for scope '{scope}'"),
-    }
+/// Look up scopes in the test theme and return a region_highlight entry for the
+/// given range, combining their foreground and background styles if needed.
+fn h<const N: usize>(start: usize, end: usize, scopes: [&str; N]) -> String {
+    let styles = scopes
+        .map(|scope| {
+            let value = TEST_THEME
+                .get(scope)
+                .unwrap_or_else(|| panic!("scope '{scope}' not found in test_theme.toml"));
+            match value {
+                toml::Value::Integer(n) => format!("fg={n}"),
+                toml::Value::Table(t) => {
+                    let bg = t["background"]
+                        .as_integer()
+                        .expect("background must be an integer");
+                    format!("bg={bg}")
+                }
+                _ => panic!("unexpected TOML value type for scope '{scope}'"),
+            }
+        })
+        .join(",");
+    format!("{start} {end} {styles}")
 }
 
 /// Common setup code required by every test in this module
@@ -186,9 +193,66 @@ async fn ls_with_option() {
         &[],
         "ls -l",
         &[
-            h(0, 2, DYNAMIC_CALLABLE_COMMAND),
-            h(2, 4, PUNCTUATION_PARAMETER),
-            h(4, 5, PARAMETER),
+            h(0, 2, [DYNAMIC_CALLABLE_COMMAND]),
+            h(2, 4, [PUNCTUATION_PARAMETER]),
+            h(4, 5, [PARAMETER]),
+        ],
+    )
+    .await;
+}
+
+/// Test if a named directory created with `hash -d` is resolved by Zsh.
+#[tokio::test]
+#[ignore]
+async fn named_directory() {
+    let image = setup().await;
+    run_highlight(
+        &image,
+        &[
+            "mkdir -p /tmp/named",
+            "touch /tmp/named/test.txt",
+            "printf '#!/bin/sh\n' > /tmp/named/test.sh",
+            "chmod u+x /tmp/named/test.sh",
+            "hash -d named=/tmp/named",
+        ],
+        &[],
+        "ls ~named/test.txt",
+        &[
+            h(0, 2, [DYNAMIC_CALLABLE_COMMAND]),
+            h(2, 3, [ARGUMENTS]),
+            h(3, 4, [TILDE, DYNAMIC_PATH_FILE_COMPLETE]),
+            h(4, 18, [ARGUMENTS, DYNAMIC_PATH_FILE_COMPLETE]),
+        ],
+    )
+    .await;
+
+    run_highlight(
+        &image,
+        &[
+            "mkdir -p /tmp/named",
+            "printf '#!/bin/sh\n' > /tmp/named/test.sh",
+            "chmod +x /tmp/named/test.sh",
+            "hash -d named=/tmp/named",
+        ],
+        &[],
+        "~named/test.sh",
+        &[
+            h(0, 1, [TILDE, DYNAMIC_CALLABLE_COMMAND]),
+            h(1, 14, [FUNCTION, DYNAMIC_CALLABLE_COMMAND]),
+        ],
+    )
+    .await;
+
+    run_highlight(
+        &image,
+        &[],
+        &[],
+        "ls ~missing/test.txt",
+        &[
+            h(0, 2, [DYNAMIC_CALLABLE_COMMAND]),
+            h(2, 3, [ARGUMENTS]),
+            h(3, 4, [TILDE]),
+            h(4, 20, [ARGUMENTS]),
         ],
     )
     .await;
@@ -207,9 +271,9 @@ async fn resolve_alias() {
         &[],
         "ll -a",
         &[
-            h(0, 2, DYNAMIC_CALLABLE_ALIAS),
-            h(2, 4, PUNCTUATION_PARAMETER),
-            h(4, 5, PARAMETER),
+            h(0, 2, [DYNAMIC_CALLABLE_ALIAS]),
+            h(2, 4, [PUNCTUATION_PARAMETER]),
+            h(4, 5, [PARAMETER]),
         ],
     )
     .await;
@@ -221,9 +285,9 @@ async fn resolve_alias() {
         &[],
         "ll -a",
         &[
-            h(0, 2, DYNAMIC_CALLABLE_ALIAS),
-            h(2, 4, PUNCTUATION_PARAMETER),
-            h(4, 5, PARAMETER),
+            h(0, 2, [DYNAMIC_CALLABLE_ALIAS]),
+            h(2, 4, [PUNCTUATION_PARAMETER]),
+            h(4, 5, [PARAMETER]),
         ],
     )
     .await;
@@ -235,9 +299,9 @@ async fn resolve_alias() {
         &[],
         "lla && ll",
         &[
-            h(0, 3, DYNAMIC_CALLABLE_ALIAS),
-            h(4, 6, OPERATOR_LOGICAL_AND),
-            h(7, 9, DYNAMIC_CALLABLE_ALIAS),
+            h(0, 3, [DYNAMIC_CALLABLE_ALIAS]),
+            h(4, 6, [OPERATOR_LOGICAL_AND]),
+            h(7, 9, [DYNAMIC_CALLABLE_ALIAS]),
         ],
     )
     .await;
@@ -248,7 +312,7 @@ async fn resolve_alias() {
         &["alias fb=foobar"],
         &[],
         "fb",
-        &[h(0, 2, DYNAMIC_CALLABLE_MISSING)],
+        &[h(0, 2, [DYNAMIC_CALLABLE_MISSING])],
     )
     .await;
 
@@ -258,7 +322,7 @@ async fn resolve_alias() {
         &["alias foobar='ls -l && echo OK'"],
         &[],
         "foobar",
-        &[h(0, 6, DYNAMIC_CALLABLE_ALIAS)],
+        &[h(0, 6, [DYNAMIC_CALLABLE_ALIAS])],
     )
     .await;
 
@@ -268,7 +332,7 @@ async fn resolve_alias() {
         &["alias foobar='ls -l && missing OK'"],
         &[],
         "foobar",
-        &[h(0, 6, DYNAMIC_CALLABLE_MISSING)],
+        &[h(0, 6, [DYNAMIC_CALLABLE_MISSING])],
     )
     .await;
 
@@ -281,7 +345,7 @@ async fn resolve_alias() {
         ],
         &[],
         "fb",
-        &[h(0, 2, DYNAMIC_CALLABLE_MISSING)],
+        &[h(0, 2, [DYNAMIC_CALLABLE_MISSING])],
     )
     .await;
 
@@ -291,7 +355,7 @@ async fn resolve_alias() {
         &["alias grep='grep --color'"],
         &[],
         "grep",
-        &[h(0, 4, DYNAMIC_CALLABLE_ALIAS)],
+        &[h(0, 4, [DYNAMIC_CALLABLE_ALIAS])],
     )
     .await;
 
@@ -303,9 +367,9 @@ async fn resolve_alias() {
         &[],
         "grep && g",
         &[
-            h(0, 4, DYNAMIC_CALLABLE_ALIAS),
-            h(5, 7, OPERATOR_LOGICAL_AND),
-            h(8, 9, DYNAMIC_CALLABLE_MISSING),
+            h(0, 4, [DYNAMIC_CALLABLE_ALIAS]),
+            h(5, 7, [OPERATOR_LOGICAL_AND]),
+            h(8, 9, [DYNAMIC_CALLABLE_MISSING]),
         ],
     )
     .await;
@@ -318,9 +382,9 @@ async fn resolve_alias() {
         &[],
         "grep && g",
         &[
-            h(0, 4, DYNAMIC_CALLABLE_ALIAS),
-            h(5, 7, OPERATOR_LOGICAL_AND),
-            h(8, 9, DYNAMIC_CALLABLE_ALIAS),
+            h(0, 4, [DYNAMIC_CALLABLE_ALIAS]),
+            h(5, 7, [OPERATOR_LOGICAL_AND]),
+            h(8, 9, [DYNAMIC_CALLABLE_ALIAS]),
         ],
     )
     .await;
@@ -341,7 +405,7 @@ async fn command_created_after_activation_in_existing_path_entry() {
             "chmod +x /tmp/bin/freshcmd",
         ],
         "freshcmd",
-        &[h(0, 8, DYNAMIC_CALLABLE_COMMAND)],
+        &[h(0, 8, [DYNAMIC_CALLABLE_COMMAND])],
     )
     .await;
 }


### PR DESCRIPTION
Hey Michel,
It's been a while! I've been sitting on a couple of tweaks that I never got around to polishing and submitting.

Here's the hairiest one: support for [*named directories*](https://zsh.sourceforge.io/Doc/Release/Expansion.html#Filename-Expansion-1).

I originally meant to support looking up other users' home directories, using `~username`; I implemented as such, and eventually wandered to the docs to figure out what they're actually called... it turns out, they're only a subset of *named directories*.

The implementation is really straightforward, but leverages a new query, which I believe then means a new version to the communication protocol.

## Preliminary `nameddir` identification problem

I actually went back and forth a lot on this one. There's one particularly puzzling bit, regarding the two `named_directory` and `potential_nameddirs` functions in `path.rs` that just have *nothing to do with one another*.
1. `potential_nameddirs` is used early on. Its responsibility is to figure out what bits of the whole command line looks like it may be a named directory. We'll take these bits, and ask the Zsh client whether they do map to anything, with an `NMD` (for "NaMeD" or "NaMed Directory") query, just like the `CAL` one.
2. `named_directory` extracts "name" of a *named directory* in what the syntax has determined to be an argument: it is notably used for highlighting in order to map names to absolute paths (and figure out whether it corresponds to an existing file or directory).

The `potential_nameddirs` one is just... not very strict. It *may* overshoot and mistakenly identify too many matches as "potential named directories". An easy example of that is:

```zsh
; echo ~olivia/log
/home/olivia/log

; echo "The ~olivia/log form refers to /home/user/olivia/log"
The ~olivia/log form refers to /home/user/olivia/log
```

Here, `potential_nameddirs` will identify `olivia` as potentially being a `nameddir`, and ask the client to resolve it, before doing going on with the highlighting pass.

Obviously, I figured that we weren't going to maintain another fully-fledged lexical parsing of the command line just for that. It's not as simple as "surrounded by whitespace", and some of them are even not surrounded by whitespace: I've identified at least `logfiles=(~liv/log)` to be an exception to that rule.

Originally, I figured I'd reuse the highlighting pass, which *does* actually do that parsing. I had it so that if that parsing yielded some named directories to be resolved, then it would resolve them through the client, and run a second pass of the highlighter.
It was rather clunky, and I'd been sort of abusing the data structure that passes arguments to the highlighter, to include its own map or list of nameddirs... Well, to be fair, it could have certainly be better, but I eventually looked at all this and figured it could just be a bit more dumb and a bit more simple.

I am actually happy enough with the current state, but I think it may still be improved somewhat.

## Pull request shape and status

I originally had several commits but considering how much I ran around like a headless chicken, I eventually just rewrote the whole thing in a one-off, clean implementation. It can still be split into several commits though :-)

1. I'll get around to writing some integration tests soon.
2. a lot of the changes are just about passing around whether to support `nameddirs`, from the current protocol. I wonder what sort of schedule we could retire previous protocols on, but when we do 1 & 2, these will be removed again.

It was also the occasion to actually look better into how the client–daemon communication protocol functions, and I'm glad I did. This reminds me of my earlier working years days, when I wasn't yet essentially a "corporate developer" and would actually build things other than convoluted microservices that presume to come together in the blandest, slowest, most finicky constellation of asynchronous, Cloud-first machination for some run-of-the-mill Web app. Ahem.