### PR TITLE
Fix daemon keeping inherited file descriptors open

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -490,6 +490,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
 
 [[package]]
+name = "close_fds"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3bc416f33de9d59e79e57560f450d21ff8393adcf1cdfc3e6d8fb93d5f88a2ed"
+dependencies = [
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3235,6 +3245,7 @@ dependencies = [
  "askama",
  "clap",
  "clap_complete",
+ "close_fds",
  "dirs",
  "env_logger",
  "figment",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ anyhow = "1.0.103"
 askama = "0.16.0"
 clap = { version = "4.5.60", features = ["derive", "wrap_help"] }
 clap_complete = "4.6.0"
+close_fds = "0.3.2"
 dirs = "6.0.0"
 env_logger = { version = "0.11.11", default-features = false, features = ["humantime"]}
 figment = { version = "0.10.19", features = ["toml"] }

--- a/src/daemon.rs
+++ b/src/daemon.rs
@@ -1407,8 +1407,16 @@ fn start_daemon_internal(
 
         // from here on, we are a true background daemon ...
 
-        // close all file descriptors so we're really decoupled from the parent
-        // process
+        // Close all file descriptors so we're really decoupled from the parent
+        // process. Keep the lock file open!
+        // SAFETY: there is only one thread so far, so `close_open_fds` is safe
+        // to call.
+        unsafe {
+            close_fds::close_open_fds(3, &[lock_file.as_raw_fd()]);
+        }
+
+        // Redirect stdin, stdout, stderr to /dev/null to further decouple from
+        // the parent.
         // SAFETY: `devnull` was just successfully opened so its fd is valid.
         // stdin/stdout/stderr are valid target fds by definition. `devnull` is
         // dropped after this block; the dup'd fds are independent copies so


### PR DESCRIPTION
## Problem

When daemonizing, `start_daemon_internal` double-forks and redirects stdin/stdout/stderr to `/dev/null`, but never closes any other inherited file descriptors. A double-fork inherits every open fd from the parent shell.

When the shell runs inside zmx and the user exits, the PTY slave is still held open by the zsh-patina daemon. A PTY master only reports EOF once all slave fds are closed, so the multiplexer never detects the shell exit. The session hangs on `exit` and the dead shell is left as an unreaped zombie process.

### Reproduction

1. Start a zsh session inside zmx
2. Stop the zsh-patina daemon `zsh-patina stop`
3. Duplicate a fd into a variable `exec {leak}>&1`
2. Ensure zsh-patina is active (`eval "$(zsh-patina activate)"`)
3. Type `exit`
4. Session hangs

## Fix

Close all inherited fds ≥ 3 after the double-fork, preserving only the lock file the daemon still needs. Fds are enumerated via `/proc/self/fd` with a bounded `getdtablesize()` fallback when `/proc` is unavailable.