### PR TITLE
Deprecate flake.nix

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ Besides normal static highlighting, zsh-patina is able to dynamically detect whe
   * [Zinit (for Zinit users)](#zinit-for-zinit-users)
   * [`.deb` package (for Debian/Ubuntu)](#deb-package-for-debianubuntu)
   * [AUR (for Arch Linux)](#aur-for-arch-linux)
-  * [flake.nix (for Nix users)](#flakenix-for-nix-users)
+  * [Nixpkgs (for Nix users)](#nixpkgs-for-nix-users)
   * [Scoop (for Windows)](#scoop-for-windows)
   * [Pre-compiled binaries (for everyone)](#pre-compiled-binaries-for-everyone)
   * [Build from source (for the brave ones)](#build-from-source-for-the-brave-ones)
@@ -128,41 +128,25 @@ zinit light michel-kraemer/zsh-patina
    exec zsh
    ```
 
-### flake.nix (for Nix users)
+### Nixpkgs (for Nix users)
 
-A flake is provided to make the executable the plugin requires available in `/nix/store`.
-
-1. Add this flake to your flake inputs:
+1. Add the executable to your `systemPackages`, making it available in your PATH (optional):
 
    ```nix
-   inputs = {
-     nixpkgs.url = "github:nixos/nixpkgs/nixos-unstable";
-     zsh-patina = {
-       url = "github:michel-kraemer/zsh-patina";
-       inputs.nixpkgs.follows = "nixpkgs";
-     };
-   }
+   environment.systemPackages = [ pkgs.zsh-patina ];
    ```
 
-2. Add the executable to your `systemPackages`, making it available in your PATH (optional):
-
-   ```nix
-   environment.systemPackages = [
-     inputs.zsh-patina.packages.${pkgs.stdenv.hostPlatform.system}.default
-   ];
-   ```
-
-3. Activate the plugin in your `.zshrc` file:
+2. Activate the plugin in your `.zshrc` file:
 
    ```shell
    # If you've added zsh-patina to systemPackages
    eval "$(zsh-patina activate)"
 
    # Reference the executable direcly
-   eval "$(${inputs.zsh-patina.packages.${pkgs.stdenv.hostPlatform.system}.default}/bin/zsh-patina activate)"
+   eval "$(${pkgs.zsh-patina}/bin/zsh-patina activate)"
    ```
 
-4. Restart your terminal, or run:
+3. Restart your terminal, or run:
 
    ```shell
    exec zsh

--- a/flake.nix
+++ b/flake.nix
@@ -19,12 +19,19 @@
         pkgs = import nixpkgs {inherit system;};
         manifest = (pkgs.lib.importTOML ./Cargo.toml).package;
       in {
-        default = pkgs.rustPlatform.buildRustPackage rec {
-          pname = manifest.name;
-          version = manifest.version;
-          cargoLock.lockFile = ./Cargo.lock;
-          src = pkgs.lib.cleanSource ./.;
-        };
+        default = pkgs.lib.warn
+          ''
+            zsh-patina has been added to nixpkgs-26.05 and nixpkgs-unstable.
+            The flake.nix in the zsh-patina repository is deprecated and will be removed.
+            Please change your configuration to use pkgs.zsh-patina from nixpkgs.
+            If unclear, consult the README of zsh-patina for instructions.
+          ''
+          (pkgs.rustPlatform.buildRustPackage rec {
+            pname = manifest.name;
+            version = manifest.version;
+            cargoLock.lockFile = ./Cargo.lock;
+            src = pkgs.lib.cleanSource ./.;
+          });
       });
     };
 }


### PR DESCRIPTION
The package is now available in nixpkgs-26.05 and nixpkgs-unstable (https://repology.org/project/zsh-patina/versions).

The flake.nix should be removed soon because it only served the purpose of making the package available to nix users. This PR adds an evaluation warning to the flake.nix which users who have updated the flake will see. I've also modified the README installation instructions accordingly.

I think the flake should only be removed entirely when some time has passed and the current version (1.9.0 as of right now) is available on stable nixpkgs (26.05). Savvy nix users who might want to run the current git commit can then still do so by overriding the `src` attribute of the package in nixpkgs.