### PR TITLE
Do not highlight directories as executable unless autocd

### DIFF
--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -837,8 +837,7 @@ pub mod tests {
             cfg.highlight("mydir")?
         );
 
-        // will be highlighted as a command (because the directory exists and is
-        // executable)
+        // will be highlighted as a dynamic callable
         assert_snapshot!(
             "directory_in_callable_position__dotslash_name",
             cfg.highlight("./mydir")?
@@ -877,8 +876,7 @@ pub mod tests {
             )?
         );
 
-        // will be highlighted as a command (similar to when autocd is not
-        // enabled)
+        // will be highlighted as a command
         assert_snapshot!(
             "directory_in_callable_position_autocd__dotslash_name",
             cfg.highlight_with_request(
@@ -998,8 +996,7 @@ pub mod tests {
             )?
         );
 
-        // will be highlighted as a command (similar to when autocd is not
-        // enabled)
+        // will be highlighted as a command
         assert_snapshot!(
             "directory_in_callable_position_partial__full_dotslash_name_autocd",
             cfg.highlight_with_request(
@@ -1084,23 +1081,41 @@ pub mod tests {
     fn command_with_tilde() -> Result<()> {
         let cfg = test_cfg()?;
 
-        assert_snapshot!("command_with_tilde__tilde", cfg.highlight("~")?);
-        assert_snapshot!("command_with_tilde__tilde_slash", cfg.highlight("~/")?);
+        assert_snapshot!(
+            "command_with_tilde__tilde",
+            cfg.highlight("~")?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
+        );
+        assert_snapshot!(
+            "command_with_tilde__tilde_slash",
+            cfg.highlight("~/")?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
+        );
         assert_snapshot!(
             "command_with_tilde__tilde_command",
             cfg.highlight("~ echo")?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
         );
         assert_snapshot!(
             "command_with_tilde__doesnotexist",
             cfg.highlight("~doesnotexist")?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
         );
         assert_snapshot!(
             "command_with_tilde__double_quoted",
             cfg.highlight(r#""~""#)?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
         );
         assert_snapshot!(
             "command_with_tilde__double_quoted_slash",
             cfg.highlight(r#""~/""#)?
+                .to_string()
+                .replace(cfg.homedir.path().to_str().unwrap(), "<HOME>")
         );
 
         Ok(())

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde.snap
@@ -1,7 +1,7 @@
 ---
 source: src/highlighting/highlighter.rs
-expression: "cfg.highlight(\"~\")?"
+expression: "cfg.highlight(\"~\")?\n.to_string().replace(cfg.homedir.path().to_str().unwrap(), \"<HOME>\")"
 ---
 ~
 
-0  1  `~`  variable.language.tilde + dynamic.callable.command
+0  1  `~`  CALLABLE `<HOME>`

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde_command.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde_command.snap
@@ -1,8 +1,8 @@
 ---
 source: src/highlighting/highlighter.rs
-expression: "cfg.highlight(\"~ echo\")?"
+expression: "cfg.highlight(\"~ echo\")?\n.to_string().replace(cfg.homedir.path().to_str().unwrap(), \"<HOME>\")"
 ---
 ~ echo
 
-0  1  `~`      variable.language.tilde + dynamic.callable.command
+0  1  `~`      CALLABLE `<HOME>`
 1  6  ` echo`  meta.function-call.arguments

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde_slash.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__command_with_tilde__tilde_slash.snap
@@ -1,8 +1,7 @@
 ---
 source: src/highlighting/highlighter.rs
-expression: "cfg.highlight(\"~/\")?"
+expression: "cfg.highlight(\"~/\")?\n.to_string().replace(cfg.homedir.path().to_str().unwrap(), \"<HOME>\")"
 ---
 ~/
 
-0  1  `~`  variable.language.tilde + dynamic.callable.command
-1  2  `/`  variable.function + dynamic.callable.command
+0  2  `~/`  CALLABLE `<HOME>/`

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__directory_in_callable_position__dotslash_name.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__directory_in_callable_position__dotslash_name.snap
@@ -4,4 +4,4 @@ expression: "cfg.highlight(\"./mydir\")?"
 ---
 ./mydir
 
-0  7  `./mydir`  variable.function + dynamic.callable.command
+0  7  `./mydir`  CALLABLE `./mydir`

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__double_quoted_callable__dir.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__double_quoted_callable__dir.snap
@@ -4,8 +4,4 @@ expression: "cfg.highlight(r#\"foo/\"bar\"/\"#)?"
 ---
 foo/"bar"/
 
-0  4   `foo/`  variable.function + dynamic.callable.command
-4  5   `"`     punctuation.definition.string.begin + dynamic.callable.command
-5  8   `bar`   string.quoted.double + dynamic.callable.command
-8  9   `"`     punctuation.definition.string.end + dynamic.callable.command
-9  10  `/`     variable.function + dynamic.callable.command
+0  10  `foo/"bar"/`  CALLABLE `foo/bar/`

--- a/src/path.rs
+++ b/src/path.rs
@@ -98,26 +98,15 @@ pub fn path_type(path: &str, pwd: &str, partial: bool) -> Option<(PathType, bool
 
 /// Check if the given path is an executable file/directory.
 /// * If the path is relative, it is resolved against the provided `pwd`.
-/// * If `autocd` is `true` and the path is a directory, it is considered
-///   executable when it is referenced by its bare name, mirroring Zsh's
-///   `AUTO_CD` option.
-/// * Otherwise, if path is a directory, it is only considered executable if it
-///   ends with a slash or if it starts with one of '/', "./", "../".
+/// * If `autocd` is `true` and the path is a traversable directory, it is
+///   considered executable, mirroring Zsh's `AUTO_CD` option.
+/// * Otherwise, directories are not executable commands.
 pub fn is_path_executable(path: &str, pwd: &str, autocd: bool) -> bool {
     let Some(metadata) = metadata(path, pwd) else {
         return false;
     };
     let is_executable = (metadata.permissions().mode() & 0o111) != 0;
-    if metadata.is_dir() {
-        is_executable
-            && (autocd
-                || path.ends_with('/')
-                || path.starts_with('/')
-                || path.starts_with("./")
-                || path.starts_with("../"))
-    } else {
-        is_executable
-    }
+    is_executable && (!metadata.is_dir() || autocd)
 }
 
 #[cfg(test)]
@@ -278,25 +267,25 @@ mod tests {
     }
 
     #[test]
-    fn is_path_executable_dir_with_slash() {
+    fn is_path_executable_dir_without_autocd() {
         let dir = tempfile::tempdir().unwrap();
         let sub = dir.path().join("mydir");
         fs::create_dir(&sub).unwrap();
 
         let path = sub.to_str().unwrap();
         assert!(path.starts_with('/'));
-        assert!(is_path_executable(path, "/", false));
+        assert!(!is_path_executable(path, "/", false));
 
-        assert!(is_path_executable("../mydir", path, false));
+        assert!(!is_path_executable("../mydir", path, false));
         assert!(!is_path_executable("../mydir2", path, false));
 
         let pwd = dir.path().to_str().unwrap();
         assert!(!is_path_executable("mydir", pwd, false));
-        assert!(is_path_executable("mydir/", pwd, false));
+        assert!(!is_path_executable("mydir/", pwd, false));
         assert!(!is_path_executable("mydir2/", pwd, false));
-        assert!(is_path_executable("./mydir", pwd, false));
+        assert!(!is_path_executable("./mydir", pwd, false));
         assert!(!is_path_executable("./mydir2", pwd, false));
-        assert!(is_path_executable("./mydir/", pwd, false));
+        assert!(!is_path_executable("./mydir/", pwd, false));
         assert!(!is_path_executable("./mydir2/", pwd, false));
     }
 


### PR DESCRIPTION
Closes #85.

~~For the snapshots to be stable across all configurations, I [set the home directory to `/tmp/home`](https://github.com/michel-kraemer/zsh-patina/blob/b89f7ff988fd95cac03b436babe92ddfca299f03/src/highlighting/highlighter.rs#L1083-L1086) in the tests.~~