### PR TITLE
Adjust completion set-up notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ extends = "nord"
 
 ## Completions (optional)
 
-> Shell completions are installed automatically by the [`.deb` package](#deb-package-for-debianubuntu) and by [Homebrew](#homebrew-for-macos).
+> Shell completions are installed automatically by the [`.deb` package](#deb-package-for-debianubuntu), by [Homebrew](#homebrew-for-macos), and by the [AUR package](#aur-for-arch-linux).
 
 If you like, you can generate shell completions for zsh-patina with the following command:
 
@@ -522,7 +522,6 @@ Alternatively, you can permanently install the script to your site-functions dir
 
 ```shell
 zsh-patina completion > /usr/local/share/zsh/site-functions/_zsh-patina
-chmod +x /usr/local/share/zsh/site-functions/_zsh-patina
 ```
 
 ## Benchmarks


### PR DESCRIPTION
Both AUR packages[^1] install the completions adequately.

[^1]: We only mention the `-git` one here (I presume that neither of us was aware of the other one), but I didn't address that with this commit. I am not particularly inclined to name both, though the `-bin` is a saner default recommendation, which only distributing versions that we release and package here, rather than building the binary from whatever is on the `master` branch whenever the user asks for a update.

Autoloaded completion files don't need to be executable, they are indeed never executed or even exactly "sourced", they merely contain *text* that corresponds to function definition.

From the chapter on Functions in the Zsh documentation:

>     For each element in fpath, the shell looks for three possible files,
>     the newest of which is used to load the definition for the function:
>
>         element.zwc           A file created with the zcompile builtin
>                               command, which is expected to contain
>                               the definitions for all functions in the
>                               directory named element [...]
>
>
>         element/function.zwc  A file created with zcompile, which is
>                               expected to contain the definition for
>                               function. [...]
>
>         element/function      A file of zsh command text, taken to be the
>                               definition for function.

In our case, the `element` is the well-known `site-functions`, and the `function` is `zsh-patina`.

Ref: https://zsh.sourceforge.io/Doc/Release/Functions.html#Autoloading-Functions