### PR TITLE
Don't verify that `zsh-patina activate` is found last in `zshrc`

### DIFF
--- a/README.md
+++ b/README.md
@@ -544,7 +544,7 @@ Fastest times are displayed in **bold**.
 
 ## Troubleshooting
 
-If the plugin doesn't work as expected, please first check if you've followed the [install instructions](#how-to-install) correctly. The plugin must be activated in your `.zshrc` file, and this must happen **at the end of the file** (after all other instructions).
+If the plugin doesn't work as expected, please first check if you've followed the [install instructions](#how-to-install) correctly. We generally recommend activating the plugin at the end of your `.zshrc` file (after all other instructions).
 
 You may also run zsh-patina's self-check:
 
@@ -553,6 +553,10 @@ zsh-patina check
 ```
 
 If the self-check doesn't find any errors, it will print `Everything is OK`. Otherwise, you will get hints about what might be wrong.
+
+### Highlighting from another plugin is missing
+
+To start with, zsh-patina preserves the highlighting regions added by other plugins. When regions overlap, Zsh combines their styles, but a later region's foreground or background color overrides an earlier one's. If zsh-patina obscures another plugin's color in such an overlap, activate zsh-patina **before** that plugin, keeping in mind that they all will run in the order they hooked themselves into the ZLE.
 
 ### Plugin has no effect on startup, but works after manual `source`
 

--- a/src/commands/check.rs
+++ b/src/commands/check.rs
@@ -1,6 +1,4 @@
 use std::{
-    fs::File,
-    io::{BufRead, BufReader},
     path::{Path, PathBuf},
     process::Command,
 };
@@ -77,33 +75,6 @@ fn print_bullet(message: &str, t: MessageType) {
 
     for l in textwrap::wrap(&message, wrap_options) {
         println!("{l}");
-    }
-}
-
-/// Gets `$ZDOTDIR` either from the environment variable or by spawning a zsh
-/// process. Returns `None` if `$ZDOTDIR` is not set or if there was an error
-/// while trying to get it.
-fn get_zdotdir() -> Result<Option<String>> {
-    if let Some(zdotdir) = std::env::var_os("ZDOTDIR")
-        && let Some(zdotdir) = zdotdir.to_str()
-    {
-        return Ok(Some(zdotdir.to_string()));
-    }
-
-    let output = Command::new("zsh").args(["-c", "echo $ZDOTDIR"]).output()?;
-
-    let val = String::from_utf8(output.stdout)?;
-    let val = val.trim().to_string();
-    Ok(if val.is_empty() { None } else { Some(val) })
-}
-
-/// Returns the path to the user's `.zshrc` file. If `$ZDOTDIR` is set, it returns
-/// `$ZDOTDIR/.zshrc`. Otherwise, it returns `~/.zshrc`.
-fn zshrc_path() -> Result<PathBuf> {
-    if let Some(zdotdir) = get_zdotdir()? {
-        Ok(PathBuf::from(zdotdir).join(".zshrc"))
-    } else {
-        Ok(PathBuf::from(shellexpand::full("~/.zshrc")?.as_ref()))
     }
 }
 
@@ -227,92 +198,6 @@ fn check_activation_current_shell() -> (String, MessageType) {
     }
 }
 
-/// Check if `zsh-patina activate` is called in the zshrc file and that it
-/// happens in the last line
-fn check_activate_in_zshrc(active_in_current_shell: bool) -> Result<(String, MessageType)> {
-    let add = if active_in_current_shell {
-        " Since zsh-patina is active in the current shell session, this might \
-        not be a problem. If everything is working correctly, you can ignore \
-        this warning."
-    } else {
-        ""
-    };
-
-    let zshrc_path = match zshrc_path() {
-        Ok(zshrc_path) => zshrc_path,
-        Err(e) => {
-            return Ok((
-                format!(
-                    "Failed to resolve path to .zshrc. Unable to check if \
-                    zsh-patina is activated when the shell is started.\n\n{e}"
-                ),
-                MessageType::Warning,
-            ));
-        }
-    };
-
-    let f = match File::open(&zshrc_path) {
-        Ok(f) => f,
-        Err(e) => {
-            return Ok((
-                format!(
-                    "Failed to read `{}'. Unable to check if zsh-patina is \
-                    activated when the shell is started.\n\n{e}",
-                    zshrc_path.to_string_lossy()
-                ),
-                MessageType::Warning,
-            ));
-        }
-    };
-
-    let reader = BufReader::new(f);
-    let mut activate_found = false;
-    let mut more_lines = false;
-    for l in reader.lines() {
-        let l = l?;
-        if l.is_empty() || l.trim().starts_with('#') {
-            continue;
-        } else {
-            more_lines = true;
-        }
-        if l.contains("zsh-patina activate")
-            || (l.contains("zinit") && l.contains("michel-kraemer/zsh-patina"))
-        {
-            activate_found = true;
-            more_lines = false;
-        }
-    }
-
-    if !activate_found {
-        return Ok((
-            format!(
-                "The string `zsh-patina activate' was not found in your .zshrc \
-                file at `{}'. Please make sure zsh-patina is activated when \
-                your shell is started.{add}",
-                zshrc_path.to_string_lossy()
-            ),
-            MessageType::Warning,
-        ));
-    }
-
-    if more_lines {
-        Ok((
-            format!(
-                "zsh-patina is not activated last in your .zshrc file at \
-                `{}'. Make sure the `zsh-patina activate' call happens at the \
-                end of the file.{add}",
-                zshrc_path.to_string_lossy()
-            ),
-            MessageType::Warning,
-        ))
-    } else {
-        Ok((
-            "zsh-patina is activated correctly in your .zshrc file.".to_string(),
-            MessageType::Success,
-        ))
-    }
-}
-
 /// Check if the daemon is running
 fn check_daemon(runtime_dir: &Path) -> Result<(String, MessageType)> {
     Ok(match is_daemon_running(runtime_dir)? {
@@ -360,15 +245,6 @@ pub fn check(
     print_bullet(&msg, t);
 
     let (msg, t) = check_activation_current_shell();
-    match t {
-        MessageType::Error => has_errors = true,
-        MessageType::Warning => has_warnings = true,
-        _ => {}
-    }
-    print_bullet(&msg, t);
-    let active_in_current_shell = t == MessageType::Success;
-
-    let (msg, t) = check_activate_in_zshrc(active_in_current_shell)?;
     match t {
         MessageType::Error => has_errors = true,
         MessageType::Warning => has_warnings = true,


### PR DESCRIPTION
1. Remove check for 'zsh-patina activate' invoked last in the zshrc
2. Merely recommend zsh-patina activation to come last in zshrc

    Additionally, provide context and explanations in the Troubleshooting
    section.

Ref: https://github.com/michel-kraemer/zsh-patina/discussions/93

---

A funny thing, in sniffing around while editing the `README`, I came to question the italics style being unsupported by Zsh. Googling for "zsh" and "italics" has *zsh-patina's README* as one of very first hits!

I looked around a bit more, came across https://github.com/zsh-users/zsh/blob/zsh-5.9/Functions/Misc/colors#L13-L24 and even https://github.com/zsh-users/zsh/commit/c01479a.

It seems to me that the `master` branch of Zsh has been fully supporting `italic` since early 2023, over 3.5 years ago! But alas, the releases we're getting come from the `zsh-5.9-patches` branch (I believe), which is a whopping 1052 behind, 482 ahead of master as I write this.

Some maintainers are fearless! Italics likely will come with 5.10.