### PR TITLE
Verify that highlighter handles named directories

### DIFF
--- a/src/highlighting/highlighter.rs
+++ b/src/highlighting/highlighter.rs
@@ -1225,6 +1225,33 @@ pub mod tests {
         Ok(())
     }
 
+    /// Test if named directories are deferred for resolution by the client
+    #[test]
+    fn named_directory() -> Result<()> {
+        let cfg = test_cfg()?;
+
+        assert_snapshot!(
+            "named_directory__argument",
+            cfg.highlight_with_request(
+                "ls ~named/test.txt",
+                HighlightingRequest::default()
+                    .with_pwd(cfg.pwd.as_str())
+                    .with_nameddirs(true),
+            )?
+        );
+        assert_snapshot!(
+            "named_directory__callable",
+            cfg.highlight_with_request(
+                "~named/test.sh",
+                HighlightingRequest::default()
+                    .with_pwd(cfg.pwd.as_str())
+                    .with_nameddirs(true),
+            )?
+        );
+
+        Ok(())
+    }
+
     #[test]
     fn path_followed_by_parameter() -> Result<()> {
         let cfg = test_cfg()?;

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__named_directory__argument.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__named_directory__argument.snap
@@ -1,0 +1,10 @@
+---
+source: src/highlighting/highlighter.rs
+expression: "cfg.highlight_with_request(\"ls ~named/test.txt\",\nHighlightingRequest::default().with_pwd(cfg.pwd.as_str()).with_nameddirs(true),)?"
+---
+ls ~named/test.txt
+
+0  2   `ls`              CALLABLE `ls`
+2  3   ` `               meta.function-call.arguments
+3  4   `~`               NAMEDDIR `~named/test.txt`
+4  18  `named/test.txt`  NAMEDDIR `~named/test.txt`

--- a/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__named_directory__callable.snap
+++ b/src/highlighting/snapshots/zsh_patina__highlighting__highlighter__tests__named_directory__callable.snap
@@ -1,0 +1,8 @@
+---
+source: src/highlighting/highlighter.rs
+expression: "cfg.highlight_with_request(\"~named/test.sh\",\nHighlightingRequest::default().with_pwd(cfg.pwd.as_str()).with_nameddirs(true),)?"
+---
+~named/test.sh
+
+0  1   `~`              NAMEDDIR `~named/test.sh`
+1  14  `named/test.sh`  NAMEDDIR `~named/test.sh`


### PR DESCRIPTION
I set both `nameddirs` and `pwd` in that highlighting request, because pre-`3` protocol versions don't use `nameddirs` and the default thus is `false`, and we get no dynamic highlighting at all without a `pwd`.

Closes #97.


