### PR TITLE
Add highlight subcommand

### DIFF
--- a/src/commands/highlight.rs
+++ b/src/commands/highlight.rs
@@ -1,0 +1,8 @@
+use anyhow::{Result, anyhow};
+
+pub fn highlight() -> Result<()> {
+    Err(anyhow!(
+        "This command is only available in a shell session where zsh-patina is \
+        activated."
+    ))
+}

--- a/src/commands/mod.rs
+++ b/src/commands/mod.rs
@@ -1,11 +1,13 @@
 mod check;
 mod completion;
+mod highlight;
 mod listscopes;
 mod listthemes;
 mod tokenize;
 
 pub use check::{check, check_config, init_check_logger};
 pub use completion::completion;
+pub use highlight::highlight;
 pub use listscopes::list_scopes;
 pub use listthemes::list_themes;
 pub use tokenize::tokenize;

--- a/src/main.rs
+++ b/src/main.rs
@@ -9,7 +9,9 @@ use figment::{
 use termcolor::{Color, ColorChoice, ColorSpec, StandardStream, WriteColor};
 
 use crate::{
-    commands::{check, completion, init_check_logger, list_scopes, list_themes, tokenize},
+    commands::{
+        check, completion, highlight, init_check_logger, list_scopes, list_themes, tokenize,
+    },
     config::{Config, config_file_path, runtime_dir},
     daemon::{activate, start_daemon, status_daemon, stop_daemon},
 };
@@ -89,11 +91,24 @@ enum Command {
     /// Check user configuration and custom theme (if applicable) for errors
     Check,
 
-    /// Tokenize a command (from a file or from stdin) and print the identified
-    /// tokens
+    /// Highlight a command line (from a file or from stdin) and print it
+    ///
+    /// This command is only available in a shell session where zsh-patina is
+    /// activated.
+    ///
+    /// Note that the command prints the plain input string without highlights
+    /// if the daemon is not running.
+    Highlight {
+        /// The input file whose contents to highlight. If this argument is not
+        /// provided, the command line will be read from stdin.
+        input_file: Option<String>,
+    },
+
+    /// Tokenize a command line (from a file or from stdin) and print the
+    /// identified tokens
     Tokenize {
-        /// The input file to tokenize. If this parameter is not provided, the
-        /// command will be read from stdin.
+        /// The input file to tokenize. If this argument is not provided, the
+        /// command line will be read from stdin.
         input_file: Option<String>,
     },
 
@@ -180,6 +195,7 @@ fn run() -> Result<()> {
         }
         Command::Status => status_daemon(&runtime_dir),
         Command::Check => check(&config, &config_file_path, &runtime_dir),
+        Command::Highlight { .. } => highlight(),
         Command::Tokenize { input_file } => tokenize(&config, &input_file),
         Command::ListScopes => list_scopes(),
         Command::ListThemes => list_themes(&config),

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -45,7 +45,7 @@ _zsh_patina_highlight_subcommand() {
         # read from file or from stdin
         if (( ${#positional[@]} == 1 )); then
             input_file="${positional[1]}"
-            if ! { [[ -r "$input_file" ]] && contents=$(<"$input_file") }; then
+            if ! { [[ -r "$input_file" ]] && [[ -f "$input_file" ]] && contents=$(<"$input_file") }; then
                 print -u2 -- "\e[31;1mzsh-patina:\e[0m Failed to read file: '$input_file'"
                 return 1
             fi

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -120,7 +120,7 @@ _zsh_patina_escape_highlighting_segment() {
 _zsh_patina_highlighting_to_formatted_string() {
     emulate -L zsh
 
-    local -a parts subparts
+    local -a parts subparts pair
     local token start end result style fgset bgset boldset underlineset
     local last=1
 
@@ -141,22 +141,25 @@ _zsh_patina_highlighting_to_formatted_string() {
         fi
         last=$(( end + 1 ))
 
+        # get formatting instructions
+        subparts=("${(s:,:)parts[3]}")
+
         # generate formatting sequences
         fgset=0
         bgset=0
         boldset=0
         underlineset=0
-        for token in "${parts[@]}"; do
+        for token in "${subparts[@]}"; do
             case "$token" in
                 fg=*)
-                    subparts=("${(s:=:)token}")
-                    result+="%F{$subparts[2]}"
+                    pair=("${(s:=:)token}")
+                    result+="%F{$pair[2]}"
                     fgset=1
                     ;;
 
                 bg=*)
-                    subparts=("${(s:=:)token}")
-                    result+="%K{$subparts[2]}"
+                    pair=("${(s:=:)token}")
+                    result+="%K{$pair[2]}"
                     bgset=1
                     ;;
 

--- a/templates/zsh-patina.zsh
+++ b/templates/zsh-patina.zsh
@@ -11,7 +11,183 @@
 export _ZSH_PATINA_PATH="<{zsh_patina_path}>"
 
 zsh-patina() {
-    "$_ZSH_PATINA_PATH" "$@"
+    # handle `highlight` subcommand
+    if [[ $1 = "highlight" ]]; then
+        _zsh_patina_highlight_subcommand "${@:2}" || return 1
+    else
+        "$_ZSH_PATINA_PATH" "$@"
+    fi
+}
+
+_zsh_patina_highlight_subcommand() {
+    local -a positional=()
+    local has_option=0
+    local seen_dashdash=0
+    local input_file
+    local contents
+
+    for a in "$@"; do
+        if (( seen_dashdash )); then
+            # everything after `--` is a positional argument
+            positional+=("$a")
+        elif [[ "$a" == "--" ]]; then
+            seen_dashdash=1
+        elif [[ "$a" == -* ]]; then
+            has_option=1
+        else
+            positional+=("$a")
+        fi
+    done
+
+    if (( has_option || ${#positional[@]} > 1 )); then
+        "$_ZSH_PATINA_PATH" highlight "$@" || return 1
+    else
+        # read from file or from stdin
+        if (( ${#positional[@]} == 1 )); then
+            input_file="${positional[1]}"
+            if ! { [[ -r "$input_file" ]] && contents=$(<"$input_file") }; then
+                print -u2 -- "\e[31;1mzsh-patina:\e[0m Failed to read file: '$input_file'"
+                return 1
+            fi
+        else
+            contents=$(cat)
+        fi
+
+        # perform the highlighting
+        _zsh_patina_highlight_string "$contents"
+        _zsh_patina_highlighting_to_formatted_string "$contents" "${reply[@]}"
+        print -rP -- "$REPLY"
+    fi
+}
+
+# Takes a command line as first argument and creates highlighting instructions
+# for `$region_highlight` within the current shell session. Assumes that the
+# cursor is at the end of the command line.
+#
+# Example:
+#
+#     _zsh_patina_highlight_string "echo hello"
+#
+# This sets `$reply` to:
+#
+#     ("0 4 fg=cyan memo=zsh_patina")
+#
+# This function is part of the `highlight` subcommand
+_zsh_patina_highlight_string() {
+    emulate -L zsh
+
+    local -ah region_highlight=()
+    local -h PREBUFFER=""
+    local -h BUFFER="$1"
+    local -h CURSOR=${#BUFFER}
+
+    # pretend our terminal is really large
+    local -h COLUMNS=2147483647
+    local -h LINES=2147483647
+
+    _zsh_patina
+
+    reply=("${region_highlight[@]}")
+}
+
+# escape a string so it can be printed verbatim using `print -P`
+_zsh_patina_escape_highlighting_segment() {
+    local input="$1"
+    input="${input//\\/\\\\}" # \  -> \\
+    input="${input//\`/\\\`}" # `  -> \`
+    input="${input//\$/\\\$}" # $  -> \$
+    input="${input//\%/%%}"   # %  -> %%
+    REPLY="$input"
+}
+
+# Takes a command line as first argument and highlighting instructions from
+# `$region_highlight` as subsequent arguments. Escapes the command line and then
+# formats it using prompt expansion sequences.
+#
+# Example:
+#
+#     _zsh_patina_highlighting_to_formatted_string "echo hello" "0 4 fg=cyan"
+#
+# This sets `$REPLY` to:
+#
+#     %F{cyan}echo%f hello
+#
+# Note: You may print the stylized command line with `print -rP`:
+#
+#     print -rP -- $REPLY
+#
+# This function is part of the `highlight` subcommand
+_zsh_patina_highlighting_to_formatted_string() {
+    emulate -L zsh
+
+    local -a parts subparts
+    local token start end result style fgset bgset boldset underlineset
+    local last=1
+
+    local input="$1"
+    (( $# > 0 )) && shift
+
+    for style in "$@"; do
+        parts=("${(s: :)style}")
+        (( ${#parts} > 1 )) || continue
+
+        start=$(( parts[1] + 1 ))
+        end=$(( parts[2] ))
+
+        # append any unformatted substring
+        if (( $start > $last )); then
+            _zsh_patina_escape_highlighting_segment "${input[$last,$start - 1]}"
+            result+="$REPLY"
+        fi
+        last=$(( end + 1 ))
+
+        # generate formatting sequences
+        fgset=0
+        bgset=0
+        boldset=0
+        underlineset=0
+        for token in "${parts[@]}"; do
+            case "$token" in
+                fg=*)
+                    subparts=("${(s:=:)token}")
+                    result+="%F{$subparts[2]}"
+                    fgset=1
+                    ;;
+
+                bg=*)
+                    subparts=("${(s:=:)token}")
+                    result+="%K{$subparts[2]}"
+                    bgset=1
+                    ;;
+
+                bold)
+                    result+="%B"
+                    boldset=1
+                    ;;
+
+                underline)
+                    result+="%U"
+                    underlineset=1
+                    ;;
+            esac
+        done
+
+        # append formatted substrings and reset formatting
+        _zsh_patina_escape_highlighting_segment "${input[$start,$end]}"
+        result+="$REPLY"
+        (( $underlineset )) && result+="%u"
+        (( $boldset )) && result+="%b"
+        (( $bgset )) && result+="%k"
+        (( $fgset )) && result+="%f"
+    done
+
+    # append unformatted remainder
+    if (( ${#input} >= $last )); then
+        _zsh_patina_escape_highlighting_segment "${input[$last,${#input}]}"
+        result+="$REPLY"
+    fi
+
+    REPLY="$result"
 }
 
 _zsh_patina_resolve_callable() {

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -14,18 +14,27 @@ use pretty_assertions::assert_eq;
 use tempfile::NamedTempFile;
 use testcontainers::{
     GenericBuildableImage, GenericImage, ImageExt,
-    core::{BuildImageOptions, Mount, WaitFor, wait::ExitWaitStrategy},
+    core::{
+        BuildImageOptions, Mount, WaitFor, logs::consumer::logging_consumer::LoggingConsumer,
+        wait::ExitWaitStrategy,
+    },
     runners::{AsyncBuilder, AsyncRunner},
 };
 use tokio::fs;
 
 const DYNAMIC_CALLABLE_ALIAS: &str = "dynamic.callable.alias.shell";
+const DYNAMIC_CALLABLE_BUILTIN: &str = "dynamic.callable.builtin.shell";
 const DYNAMIC_CALLABLE_COMMAND: &str = "dynamic.callable.command.shell";
 const DYNAMIC_CALLABLE_MISSING: &str = "dynamic.callable.missing.shell";
+const DYNAMIC_PATH_DIRECTORY_COMPLETE: &str = "dynamic.path.directory.complete.shell";
 const DYNAMIC_PATH_FILE_COMPLETE: &str = "dynamic.path.file.complete.shell";
 const ARGUMENTS: &str = "meta.function-call.arguments.shell";
+const KEYWORD_TIME: &str = "keyword.control.flow.time.shell";
 const OPERATOR_LOGICAL_AND: &str = "keyword.operator.logical.and.shell";
+const STRING_QUOTED_DOUBLE: &str = "string.quoted.double.shell";
 const PUNCTUATION_PARAMETER: &str = "punctuation.definition.parameter.shell";
+const PUNCTUATION_STRING_BEGIN: &str = "punctuation.definition.string.begin.shell";
+const PUNCTUATION_STRING_END: &str = "punctuation.definition.string.end.shell";
 const PARAMETER: &str = "variable.parameter.option.shell";
 const FUNCTION: &str = "variable.function.shell";
 const TILDE: &str = "variable.language.tilde.shell";
@@ -57,6 +66,80 @@ fn h<const N: usize>(start: usize, end: usize, scopes: [&str; N]) -> String {
         })
         .join(",");
     format!("{start} {end} {styles}")
+}
+
+/// Format a command line with the given spans applying xterm 256 color codes
+/// (using short forms where possible)
+fn xterm_256color<const N: usize>(command_line: &str, spans: [(usize, usize, &str); N]) -> Vec<u8> {
+    #[derive(PartialEq, Eq, PartialOrd, Ord)]
+    #[repr(u8)]
+    enum Event {
+        EndBg = 0,
+        EndFg = 1,
+        StartFg(i64) = 2,
+        StartBg(i64) = 3,
+    }
+
+    let mut events = Vec::new();
+    for (start, end, scope) in spans {
+        let value = TEST_THEME
+            .get(scope)
+            .unwrap_or_else(|| panic!("scope '{scope}' not found in test_theme.toml"));
+        match value {
+            toml::Value::Integer(n) => {
+                events.push((start, Event::StartFg(*n)));
+                events.push((end, Event::EndFg));
+            }
+            toml::Value::Table(t) => {
+                let n = t["background"]
+                    .as_integer()
+                    .expect("background must be an integer");
+                events.push((start, Event::StartBg(n)));
+                events.push((end, Event::EndBg));
+            }
+            _ => panic!("unexpected TOML value type for scope '{scope}'"),
+        }
+    }
+
+    // sort by index, then close all end events first (bg before fg) and then
+    // open all start events (fg before bg)
+    events.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.cmp(&b.1)));
+
+    let bytes = command_line.as_bytes();
+    let mut result = Vec::new();
+    let mut pos = 0;
+
+    for (i, e) in events {
+        while pos < i {
+            result.push(bytes[pos]);
+            pos += 1;
+        }
+
+        match e {
+            Event::EndBg => result.extend(b"\x1B[49m"),
+            Event::EndFg => result.extend(b"\x1B[39m"),
+            Event::StartFg(n) => {
+                let f = match n {
+                    0..=7 => format!("\x1B[3{}m", n),      // normal colors
+                    8..=15 => format!("\x1B[9{}m", n - 8), // bright colors
+                    _ => format!("\x1B[38;5;{n}m"),        // 256-color form
+                };
+                result.extend(f.as_bytes());
+            }
+            Event::StartBg(n) => {
+                let f = match n {
+                    0..=7 => format!("\x1B[4{}m", n),       // normal colors
+                    8..=15 => format!("\x1B[10{}m", n - 8), // bright colors
+                    _ => format!("\x1B[48;5;{n}m"),         // 256-color form
+                };
+                result.extend(f.as_bytes());
+            }
+        }
+    }
+
+    result.extend(&bytes[pos..]);
+
+    result
 }
 
 /// Common setup code required by every test in this module
@@ -130,9 +213,10 @@ async fn run_highlight(
         .next_back()
         .map(|(idx, _)| &buffer[..idx])
         .unwrap_or("");
+
     // Trigger highlighting repeatedly in a loop until the daemon has fully
     // started and $region_highlight is actually filled
-    let highlight_loop = "CURSOR=${#BUFFER}; for i in {1..50}; do _zsh_patina; [[ ${#region_highlight[@]} -gt 0 ]] && break; sleep 0.1; done;";
+    let highlight_loop = "CURSOR=${#BUFFER}; for i in {1..300}; do _zsh_patina; [[ ${#region_highlight[@]} -gt 0 ]] && break; sleep 0.1; done;";
     let zsh_script = format!(
         r#"{before_activate}
         eval "$(zsh-patina activate)"
@@ -143,6 +227,91 @@ async fn run_highlight(
         printf '%s\n' "${{region_highlight[@]}}""#
     );
 
+    let (stdout_bytes, exit_code) = run_container(zsh_script, image).await;
+
+    let stdout = std::str::from_utf8(&stdout_bytes)
+        .expect("stdout is not valid UTF-8")
+        .to_string();
+
+    let lines = stdout
+        .lines()
+        .map(|l| {
+            l.strip_suffix(" memo=zsh_patina")
+                .expect("region_highlight entry must end with ` memo=zsh_patina'")
+        })
+        .collect::<Vec<_>>();
+
+    assert_eq!(lines, expected);
+    assert_eq!(exit_code, 0);
+}
+
+/// Runs the `highlight` subcommand in a container using the given arguments and
+/// stdin. Return stdout and the subcommand's exit code.
+async fn run_highlight_subcommand(
+    image: &GenericImage,
+    setup_pre: &[&str],
+    args: &[&str],
+    stdin: &str,
+) -> (Vec<u8>, i64) {
+    let before_activate = if setup_pre.is_empty() {
+        String::new()
+    } else {
+        format!("{}; ", setup_pre.join("; "))
+    };
+
+    // Wait for the daemon to come up by polling until `zsh-patina status`
+    // succeeds. Without this, the `highlight` subcommand will render the
+    // unhighlighted input (see the command's documentation).
+    let wait_daemon =
+        "for i in {1..300}; do zsh-patina status >/dev/null 2>&1 && break; sleep 0.1; done;";
+
+    let zsh_script = format!(
+        r#"{before_activate}
+        eval "$(zsh-patina activate)"
+        {wait_daemon}
+        export TERM=xterm-256color  # make sure the command's output is colored
+        zsh-patina highlight {} <<'EOF'
+{stdin}
+EOF"#,
+        args.join(" ")
+    );
+
+    run_container(zsh_script, image).await
+}
+
+/// Runs the `highlight` subcommand in a container using the given arguments and
+/// stdin. Compares stdout with the given expected bytes.
+async fn assert_highlight_subcommand(
+    image: &GenericImage,
+    setup_pre: &[&str],
+    args: &[&str],
+    stdin: &str,
+    expected: &[u8],
+) {
+    let (stdout_bytes, exit_code) = run_highlight_subcommand(image, setup_pre, args, stdin).await;
+
+    if stdout_bytes != expected {
+        // print stdout in human-readable form for better debugging
+        eprintln!(
+            "stdout: {}",
+            stdout_bytes
+                .iter()
+                .map(|&b| if b >= 32 {
+                    (b as char).to_string()
+                } else {
+                    format!("\\x{b:0>2x}")
+                })
+                .collect::<Vec<_>>()
+                .join("")
+        );
+    }
+    assert_eq!(stdout_bytes, expected);
+    assert_eq!(exit_code, 0);
+}
+
+/// Runs a given zsh script in a Docker image. Mounts a zsh-patina configuration
+/// and the test theme into the container.
+async fn run_container(zsh_script: String, image: &GenericImage) -> (Vec<u8>, i64) {
     let config = "[highlighting]\ntheme = \"file:/root/.config/zsh-patina/test_theme.toml\"";
     let config_file = NamedTempFile::new().expect("Unable to create temporary config file");
     fs::write(&config_file, config)
@@ -161,25 +330,22 @@ async fn run_highlight(
             "/root/.config/zsh-patina/test_theme.toml",
         ))
         .with_cmd(["unbuffer", "zsh", "-c", &zsh_script])
+        .with_log_consumer(LoggingConsumer::new())
         .start()
         .await
         .expect("failed to start container");
 
-    let stdout_bytes = container
+    let stdout = container
         .stdout_to_vec()
         .await
         .expect("failed to read stdout");
-    let stdout = std::str::from_utf8(&stdout_bytes).expect("stdout is not valid UTF-8");
+    let exit_code = container
+        .exit_code()
+        .await
+        .expect("failed to read exit code")
+        .unwrap();
 
-    let lines = stdout
-        .lines()
-        .map(|l| {
-            l.strip_suffix(" memo=zsh_patina")
-                .expect("region_highlight entry must end with ` memo=zsh_patina'")
-        })
-        .collect::<Vec<_>>();
-
-    assert_eq!(lines, expected);
+    (stdout, exit_code)
 }
 
 /// Test if a simple `ls -l` command is highlighted correctly
@@ -408,4 +574,177 @@ async fn command_created_after_activation_in_existing_path_entry() {
         &[h(0, 8, [DYNAMIC_CALLABLE_COMMAND])],
     )
     .await;
+}
+
+/// Use the `highlight` subcommand to highlight a simple command
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_simple_command() {
+    let image = setup().await;
+
+    assert_highlight_subcommand(
+        &image,
+        &[],
+        &[],
+        "time ls",
+        &xterm_256color(
+            "time ls\n",
+            [(0, 4, KEYWORD_TIME), (5, 7, DYNAMIC_CALLABLE_COMMAND)],
+        ),
+    )
+    .await;
+}
+
+/// Use the `highlight` subcommand to highlight a command with a directory
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_command_with_dir() {
+    let image = setup().await;
+
+    assert_highlight_subcommand(
+        &image,
+        &[],
+        &[],
+        "ls /test",
+        &xterm_256color(
+            "ls /test\n",
+            [(0, 2, DYNAMIC_CALLABLE_COMMAND), (2, 8, ARGUMENTS)],
+        ),
+    )
+    .await;
+
+    assert_highlight_subcommand(
+        &image,
+        &["mkdir /test"],
+        &[],
+        "ls /test",
+        &xterm_256color(
+            "ls /test\n",
+            [
+                (0, 2, DYNAMIC_CALLABLE_COMMAND),
+                (2, 3, ARGUMENTS),
+                (3, 8, ARGUMENTS),
+                (3, 8, DYNAMIC_PATH_DIRECTORY_COMPLETE),
+            ],
+        ),
+    )
+    .await;
+}
+
+/// Use the `highlight` subcommand and highlight a command line from a file
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_from_file() {
+    let image = setup().await;
+
+    assert_highlight_subcommand(
+        &image,
+        &["echo 'echo \"Hello world\"' > /tmp/command-line.zsh"],
+        &["/tmp/command-line.zsh"],
+        "",
+        &xterm_256color(
+            "echo \"Hello world\"\n",
+            [
+                (0, 4, DYNAMIC_CALLABLE_BUILTIN),
+                (4, 5, ARGUMENTS),
+                (5, 6, PUNCTUATION_STRING_BEGIN),
+                (6, 17, STRING_QUOTED_DOUBLE),
+                (17, 18, PUNCTUATION_STRING_END),
+            ],
+        ),
+    )
+    .await;
+
+    assert_highlight_subcommand(
+        &image,
+        &["echo 'echo OK' > -h"],
+        &["--", "-h"],
+        "",
+        &xterm_256color(
+            "echo OK\n",
+            [(0, 4, DYNAMIC_CALLABLE_BUILTIN), (4, 7, ARGUMENTS)],
+        ),
+    )
+    .await;
+}
+
+/// Test that the `highlight` subcommand fails if an input file does not exist
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_nonexistent_input_file() {
+    let image = setup().await;
+
+    let (stdout, exit_code) =
+        run_highlight_subcommand(&image, &[], &["/tmp/command-line.zsh"], "").await;
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        std::str::from_utf8(&stdout).unwrap(),
+        "\x1B[31;1mzsh-patina:\x1B[0m Failed to read file: '/tmp/command-line.zsh'\n",
+    );
+}
+
+/// Test that the `highlight` subcommand fails if the input file is a directory
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_input_is_dir() {
+    let image = setup().await;
+
+    let (stdout, exit_code) =
+        run_highlight_subcommand(&image, &["mkdir /temp"], &["/temp"], "").await;
+    assert_eq!(exit_code, 1);
+    assert_eq!(
+        std::str::from_utf8(&stdout).unwrap(),
+        "\x1B[31;1mzsh-patina:\x1B[0m Failed to read file: '/temp'\n",
+    );
+}
+
+/// Test that the `highlight` subcommand shows the help
+#[tokio::test]
+#[ignore]
+async fn highlight_subcommand_help() {
+    let image = setup().await;
+
+    let (stdout, exit_code) = run_highlight_subcommand(&image, &[], &["-h"], "").await;
+    assert_eq!(exit_code, 0);
+    assert!(std::str::from_utf8(&stdout).unwrap().contains("Usage:"));
+
+    let (stdout, exit_code) = run_highlight_subcommand(&image, &[], &["--help"], "").await;
+    assert_eq!(exit_code, 0);
+    assert!(std::str::from_utf8(&stdout).unwrap().contains("Usage:"));
+
+    // show help even if there is a file given
+    let (stdout, exit_code) = run_highlight_subcommand(&image, &[], &["-h", "file.txt"], "").await;
+    assert_eq!(exit_code, 0);
+    assert!(std::str::from_utf8(&stdout).unwrap().contains("Usage:"));
+
+    // show help even if there is a file given
+    let (stdout, exit_code) =
+        run_highlight_subcommand(&image, &[], &["-h", "--", "file.txt"], "").await;
+    assert_eq!(exit_code, 0);
+    assert!(std::str::from_utf8(&stdout).unwrap().contains("Usage:"));
+
+    let (stdout, exit_code) = run_highlight_subcommand(&image, &[], &["-a"], "").await;
+    assert_eq!(exit_code, 1);
+    assert!(
+        std::str::from_utf8(&stdout)
+            .unwrap()
+            .contains("unexpected argument"),
+    );
+
+    let (stdout, exit_code) = run_highlight_subcommand(&image, &[], &["file1", "file2"], "").await;
+    assert_eq!(exit_code, 1);
+    assert!(
+        std::str::from_utf8(&stdout)
+            .unwrap()
+            .contains("unexpected argument"),
+    );
+
+    let (stdout, exit_code) =
+        run_highlight_subcommand(&image, &[], &["file1", "--", "file2"], "").await;
+    assert_eq!(exit_code, 1);
+    assert!(
+        std::str::from_utf8(&stdout)
+            .unwrap()
+            .contains("unexpected argument"),
+    );
 }


### PR DESCRIPTION
This PR adds a `highlight` subcommand that takes a command line, highlights it, and prints the results to stdout. The command only works within a shell session where zsh-patina is activated and only if the daemon is running.

Closes #90 