### PR TITLE
Support colonless numeric history expansion word designators

### DIFF
--- a/src/highlighting/historyexpansion.rs
+++ b/src/highlighting/historyexpansion.rs
@@ -245,16 +245,13 @@ fn consume_until_non_escaped(chars: &[(usize, char)], mut i: usize, until: char)
 /// word designator if successful, or None if there is no valid word designator
 /// at index i.
 fn consume_word_designator(chars: &[(usize, char)], mut i: usize) -> Option<usize> {
-    // Consume leading colon. If the colon is missing, the next character must
-    // not be a digit. In other words, the colon is optional if the word
-    // designator starts with one of '^', '$', '%', '-', '*'
+    // Event parsing has already consumed digits belonging to an event number,
+    // so a remaining digit is an unambiguous word designator.
     if chars[i].1 == ':' {
         i += 1;
         if i == chars.len() {
             return Some(i);
         }
-    } else if chars[i].1.is_ascii_digit() {
-        return None;
     }
 
     // consume range start
@@ -842,6 +839,9 @@ mod tests {
 
     #[test]
     fn both_designators() {
+        assert_expanded("ls -l !!1", &[vec![(6, 9)]]);
+        assert_expanded("ls -l !#1:t", &[vec![(6, 11)]]);
+        assert_expanded("ls -l !?cp?1:t", &[vec![(6, 14)]]);
         assert_expanded("ls -l !cp:2", &[vec![(6, 11)]]);
         assert_expanded("ls -l !cp:$", &[vec![(6, 11)]]);
         assert_expanded("ls -l !cp:^", &[vec![(6, 11)]]);


### PR DESCRIPTION
Using history expansion, the implementation of Zsh allows the omission of the colon before some numeric word designators, following:

    !!, !#, and !?str?, for example !!2, !#1, and !?test?4:t.

The implementation has been exhibiting that behaviour since the earliest revision in Zsh's Git repository, with [e74702b46](https://github.com/zsh-users/zsh/commit/e74702b467171dbdafb56dfe354794a212e020d9) (Initial revision, 1999-04-15), but the manual currently says that the colon may only be omitted before:

    ^, $, *, -, or %.

For example, you may very well do:

    mkdir /tmp/asdf && cd !#1

The documentation is being amended upstream to rectify that situation.

Ref: https://www.zsh.org/mla/users/2026/msg00148.html
Ref: https://www.zsh.org/mla/workers/2026/msg00981.html